### PR TITLE
Enhanced files app integration

### DIFF
--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -510,7 +510,11 @@ class EditorController extends Controller {
             "shareToken" => $shareToken
         ];
 
-        $response = new TemplateResponse($this->appName, "editor", $params);
+        if ($this->config->GetSameTab()) {
+            $response = new TemplateResponse($this->appName, "editor", $params, 'plain');
+        } else {
+            $response = new TemplateResponse($this->appName, "editor", $params);
+        }
 
         $csp = new ContentSecurityPolicy();
         $csp->allowInlineScript(true);

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -252,7 +252,8 @@ class SettingsController extends Controller {
     public function GetSettings() {
         $result = [
             "formats" => $this->config->FormatsSetting(),
-            "sameTab" => $this->config->GetSameTab()
+            "sameTab" => $this->config->GetSameTab(),
+            "documentserver" => $this->config->GetDocumentServerUrl(),
         ];
         return $result;
     }

--- a/css/editor.css
+++ b/css/editor.css
@@ -29,6 +29,32 @@
 #content.app-onlyoffice {
     min-height: calc(100% - 50px);
 }
+
+#body-public #content {
+    height: 100%;
+}
+
+#close {
+    position: absolute;
+    z-index: 100;
+    right: 80px;
+    height: 32px;
+    width: 40px;
+}
+
+#details {
+    position: absolute;
+    z-index: 100;
+    right: 120px;
+    height: 32px;
+    width: 40px;
+}
+
+#close:hover,
+#details:hover {
+    background-color: #d8dadc;
+}
+
 #app > iframe {
     position: absolute;
     vertical-align: top;

--- a/css/main.css
+++ b/css/main.css
@@ -40,6 +40,16 @@
     background-image: url("../img/app-dark.svg");
 }
 
+#onlyoffice_viewer {
+    background-color: #fff;
+    width: 100%;
+    height: calc(100vh - 50px);
+    display: block;
+    position: absolute;
+    top: 0;
+    z-index: 110;
+}
+
 .AscDesktopEditor #body-user #header {
     display: none;
 }

--- a/js/editor.js
+++ b/js/editor.js
@@ -115,6 +115,10 @@
 
                     config.events = {
                         "onDocumentStateChange": setPageTitle,
+                        /* FIXME: this doesn't work as expected */
+                        "onRequestClose": function () {
+                            console.log('onRequestClose')
+                        }
                     };
 
                     if (OC.currentUser) {

--- a/js/editor.js
+++ b/js/editor.js
@@ -28,6 +28,14 @@
 
 (function ($, OCA) {
 
+    document.getElementById('close').addEventListener('click', function () {
+        parent.postMessage('close');
+    });
+
+    document.getElementById('details').addEventListener('click', function () {
+        parent.postMessage('toggleFilesSidebar');
+    })
+
     OCA.Onlyoffice = _.extend({
             AppName: "onlyoffice"
         }, OCA.Onlyoffice);

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -590,7 +590,7 @@ class AppConfig {
      * @return bool
      */
     public function GetSameTab() {
-        return $this->config->getAppValue($this->appName, $this->_sameTab, "false") === "true";
+        return $this->config->getAppValue($this->appName, $this->_sameTab, "true") === "true";
     }
 
     /**

--- a/templates/editor.php
+++ b/templates/editor.php
@@ -34,6 +34,9 @@
 
 <div id="app">
 
+	<div id="close" class="icon-close"></div>
+	<div id="details" class="icon-share"></div>
+
     <div id="iframeEditor" data-id="<?php p($_["fileId"]) ?>" data-path="<?php p($_["filePath"]) ?>" data-sharetoken="<?php p($_["shareToken"]) ?>"></div>
 
     <?php if (!empty($_["documentServerUrl"])) { ?>


### PR DESCRIPTION
This is the first PoC of a better integration in the Nextcloud files app. The goal is to open the editor inside of an iframe that is overlayed over the file list.


4045c94 is only a temporary commit. I digged around in the OnlyOffice code a bit and found the [onRequestClose](https://api.onlyoffice.com/editors/config/events#onRequestClose) which seemed to be somehow usable for that but I couldn't get that event triggered. However we need to have a way to trigger the close action and the show sidebar action from within OnlyOffice. Once that is catched a postMessage to the Nextcloud parent frame can be emitted ([similar to this](https://github.com/ONLYOFFICE/onlyoffice-nextcloud/commit/4045c94a57e72f2af15d455c2a8ee3ecaf0f09de#diff-f9fa84d520bfade2b893ee11278fde2eR31-R37)) to toggle the files sidebar and close the view. @LinneyS Is that something you could easily implement on your side?

## Screencast

![Peek 2019-10-14 16-46](https://user-images.githubusercontent.com/3404133/66760357-3acae980-eea2-11e9-9190-695df000dece.gif)
