### PR TITLE
Option to open all files read only by default

### DIFF
--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -467,7 +467,7 @@ class EditorController extends Controller {
      * @NoAdminRequired
      * @NoCSRFRequired
      */
-    public function index($fileId, $filePath = null, $shareToken = null, $inframe = false) {
+    public function index($fileId, $filePath = null, $shareToken = null, $inframe = false, $readonly = false) {
         $this->logger->debug("Open: $fileId $filePath", ["app" => $this->appName]);
 
         $isLoggedIn = $this->userSession->isLoggedIn();
@@ -561,7 +561,7 @@ class EditorController extends Controller {
      * @NoAdminRequired
      * @PublicPage
      */
-    public function config($fileId, $filePath = null, $shareToken = null, $directToken = null, $inframe = 0, $desktop = false) {
+    public function config($fileId, $filePath = null, $shareToken = null, $directToken = null, $inframe = 0, $desktop = false, $readonly = false) {
 
         if (!empty($directToken)) {
             list ($directData, $error) = $this->crypt->ReadHash($directToken);
@@ -641,6 +641,8 @@ class EditorController extends Controller {
         $canEdit = isset($format["edit"]) && $format["edit"];
         $editable = $file->isUpdateable()
                     && (empty($shareToken) || ($share->getPermissions() & Constants::PERMISSION_UPDATE) === Constants::PERMISSION_UPDATE);
+        if ($readonly)
+        	$editable = false;
         $params["document"]["permissions"]["edit"] = $editable;
         if ($editable && $canEdit) {
             $hashCallback = $this->crypt->GetHash(["userId" => $userId, "fileId" => $file->getId(), "filePath" => $filePath, "shareToken" => $shareToken, "action" => "track"]);

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -122,6 +122,7 @@ class SettingsController extends Controller {
             "currentServer" => $this->urlGenerator->getAbsoluteURL("/"),
             "formats" => $this->config->FormatsSetting(),
             "sameTab" => $this->config->GetSameTab(),
+            "readOnly" => $this->config->GetReadOnly(),
             "limitGroups" => $this->config->GetLimitGroups(),
             "chat" => $this->config->GetCustomizationChat(),
             "compactHeader" => $this->config->GetCustomizationCompactHeader(),
@@ -189,6 +190,7 @@ class SettingsController extends Controller {
      * @param array $defFormats - formats array with default action
      * @param array $editFormats - editable formats array
      * @param bool $sameTab - open in the same tab
+     * @param bool $readOnly - click opens read only
      * @param array $limitGroups - list of groups
      * @param bool $chat - display chat
      * @param bool $compactHeader - display compact header
@@ -202,6 +204,7 @@ class SettingsController extends Controller {
     public function SaveCommon($defFormats,
                                     $editFormats,
                                     $sameTab,
+                                    $readOnly,
                                     $limitGroups,
                                     $chat,
                                     $compactHeader,
@@ -214,6 +217,7 @@ class SettingsController extends Controller {
         $this->config->SetDefaultFormats($defFormats);
         $this->config->SetEditableFormats($editFormats);
         $this->config->SetSameTab($sameTab);
+        $this->config->SetReadOnly($readOnly);
         $this->config->SetLimitGroups($limitGroups);
         $this->config->SetCustomizationChat($chat);
         $this->config->SetCustomizationCompactHeader($compactHeader);
@@ -259,7 +263,8 @@ class SettingsController extends Controller {
     public function GetSettings() {
         $result = [
             "formats" => $this->config->FormatsSetting(),
-            "sameTab" => $this->config->GetSameTab()
+            "sameTab" => $this->config->GetSameTab(),
+            "readOnly" => $this->config->GetReadOnly()
         ];
         return $result;
     }

--- a/js/editor.js
+++ b/js/editor.js
@@ -91,6 +91,9 @@
         if (OCA.Onlyoffice.Desktop) {
             params.push("desktop=true");
         }
+        if (window.location.search.includes("&readonly=1")) {
+        	params.push("readonly=true");
+		}
         if (params.length) {
             configUrl += "?" + params.join("&");
         }

--- a/js/main.js
+++ b/js/main.js
@@ -79,7 +79,7 @@
         );
     };
 
-    OCA.Onlyoffice.OpenEditor = function (fileId, fileDir, fileName, winEditor) {
+    OCA.Onlyoffice.OpenEditor = function (fileId, fileDir, fileName, winEditor, readonly) {
         var filePath = fileDir.replace(new RegExp("\/$"), "") + "/" + fileName;
         var url = OC.generateUrl("/apps/" + OCA.Onlyoffice.AppName + "/{fileId}?filePath={filePath}",
             {
@@ -94,7 +94,8 @@
                     fileId: fileId
                 });
         }
-
+		if (readonly)
+			url += '&readonly=1';
         if (winEditor && winEditor.location) {
             winEditor.location.href = url;
         } else if (!OCA.Onlyoffice.setting.sameTab || OCA.Onlyoffice.Desktop) {
@@ -128,6 +129,14 @@
     };
 
     OCA.Onlyoffice.FileClick = function (fileName, context) {
+        var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
+        OCA.Onlyoffice.OpenEditor(fileInfoModel.id, context.dir, fileName, null, true);
+
+        OCA.Onlyoffice.context = context;
+        OCA.Onlyoffice.context.fileName = fileName;
+    };
+
+    OCA.Onlyoffice.FileEditClick = function (fileName, context) {
         var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
         OCA.Onlyoffice.OpenEditor(fileInfoModel.id, context.dir, fileName);
 
@@ -205,6 +214,15 @@
 
                     if (config.def) {
                         fileList.fileActions.setDefault(config.mime, "onlyofficeOpen");
+						OCA.Files.fileActions.registerAction({
+							name: 'edit_onlyoffice',
+							displayName: t('edit_onlyoffice', 'Open for editing'),
+							mime: config.mime,
+							actionHandler: OCA.Onlyoffice.FileEditClick,
+							permissions: OC.PERMISSION_UPDATE,
+							iconClass: 'icon-edit'
+						});
+
                     }
 
                     if (config.conv) {
@@ -216,6 +234,14 @@
                             iconClass: "icon-onlyoffice-convert",
                             actionHandler: OCA.Onlyoffice.FileConvertClick
                         });
+						fileList.fileActions.registerAction({
+							name: "onlyofficeOpen",
+							displayName: t(OCA.Onlyoffice.AppName, "Open for editing in ONLYOFFICE"),
+							mime: config.mime,
+							permissions: OC.PERMISSION_UPDATE,
+							iconClass: "icon-onlyoffice-open",
+							actionHandler: OCA.Onlyoffice.FileEditClick
+						});
                     }
                 });
             }

--- a/js/main.js
+++ b/js/main.js
@@ -130,7 +130,7 @@
 
     OCA.Onlyoffice.FileClick = function (fileName, context) {
         var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
-        OCA.Onlyoffice.OpenEditor(fileInfoModel.id, context.dir, fileName, null, true);
+        OCA.Onlyoffice.OpenEditor(fileInfoModel.id, context.dir, fileName, null, OCA.Onlyoffice.setting.readOnly);
 
         OCA.Onlyoffice.context = context;
         OCA.Onlyoffice.context.fileName = fileName;
@@ -214,14 +214,15 @@
 
                     if (config.def) {
                         fileList.fileActions.setDefault(config.mime, "onlyofficeOpen");
-						OCA.Files.fileActions.registerAction({
-							name: 'edit_onlyoffice',
-							displayName: t('edit_onlyoffice', 'Open for editing'),
-							mime: config.mime,
-							actionHandler: OCA.Onlyoffice.FileEditClick,
-							permissions: OC.PERMISSION_UPDATE,
-							iconClass: 'icon-edit'
-						});
+                        if (OCA.Onlyoffice.setting.readOnly)
+							OCA.Files.fileActions.registerAction({
+								name: 'edit_onlyoffice',
+								displayName: t('edit_onlyoffice', 'Open for editing'),
+								mime: config.mime,
+								actionHandler: OCA.Onlyoffice.FileEditClick,
+								permissions: OC.PERMISSION_UPDATE,
+								iconClass: 'icon-edit'
+							});
 
                     }
 
@@ -234,14 +235,15 @@
                             iconClass: "icon-onlyoffice-convert",
                             actionHandler: OCA.Onlyoffice.FileConvertClick
                         });
-						fileList.fileActions.registerAction({
-							name: "onlyofficeOpen",
-							displayName: t(OCA.Onlyoffice.AppName, "Open for editing in ONLYOFFICE"),
-							mime: config.mime,
-							permissions: OC.PERMISSION_UPDATE,
-							iconClass: "icon-onlyoffice-open",
-							actionHandler: OCA.Onlyoffice.FileEditClick
-						});
+                        if (OCA.Onlyoffice.setting.readOnly)
+							fileList.fileActions.registerAction({
+								name: "onlyofficeOpen",
+								displayName: t(OCA.Onlyoffice.AppName, "Open for editing in ONLYOFFICE"),
+								mime: config.mime,
+								permissions: OC.PERMISSION_UPDATE,
+								iconClass: "icon-onlyoffice-open",
+								actionHandler: OCA.Onlyoffice.FileEditClick
+							});
                     }
                 });
             }

--- a/js/settings.js
+++ b/js/settings.js
@@ -198,6 +198,7 @@
             });
 
             var sameTab = $("#onlyofficeSameTab").is(":checked");
+            var readOnly = $("#onlyofficeReadOnly").is(":checked");
 
             var limitGroupsString = $("#onlyofficeGroups").prop("checked") ? $("#onlyofficeLimitGroups").val() : "";
             var limitGroups = limitGroupsString ? limitGroupsString.split("|") : [];
@@ -216,6 +217,7 @@
                     defFormats: defFormats,
                     editFormats: editFormats,
                     sameTab: sameTab,
+                    readOnly: readOnly,
                     limitGroups: limitGroups,
                     chat: chat,
                     compactHeader: compactHeader,

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -120,6 +120,13 @@ class AppConfig {
     private $_sameTab = "sameTab";
 
     /**
+     * The config key for the setting read only
+     *
+     * @var string
+     */
+    private $_readOnly = "readOnly";
+
+    /**
      * The config key for the chat display setting
      *
      * @var string
@@ -613,6 +620,26 @@ class AppConfig {
      */
     public function GetSameTab() {
         return $this->config->getAppValue($this->appName, $this->_sameTab, "false") === "true";
+    }
+
+    /**
+     * Save the opening setting in a read only
+     *
+     * @param bool $value - same tab
+     */
+    public function SetReadOnly($value) {
+        $this->logger->info("Set opening in a same tab: " . json_encode($value), ["app" => $this->appName]);
+
+        $this->config->setAppValue($this->appName, $this->_readOnly, json_encode($value));
+    }
+
+    /**
+     * Get the opening setting in a read only
+     *
+     * @return bool
+     */
+    public function GetReadOnly() {
+        return $this->config->getAppValue($this->appName, $this->_readOnly, "false") === "true";
     }
 
     /**

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -109,6 +109,12 @@
         <label for="onlyofficeSameTab"><?php p($l->t("Open file in the same tab")) ?></label>
     </p>
 
+    <p>
+        <input type="checkbox" class="checkbox" id="onlyofficeReadOnly"
+            <?php if ($_["readOnly"]) { ?>checked="checked"<?php } ?> />
+        <label for="onlyofficeReadOnly"><?php p($l->t("Clicking on file opens it read only")) ?></label>
+    </p>
+
     <p class="onlyoffice-header"><?php p($l->t("The default application for opening the format")) ?></p>
     <div class="onlyoffice-exts">
         <?php foreach ($_["formats"] as $format => $setting) { ?>


### PR DESCRIPTION
We wanted users to be able to view Only Office files by default, rather than always being in edit mode, where it is too easy to make changes by mistake.

This branch adds a setting to turn that on, so:

- Clicking an existing file opens it read only
- Creating a new file opens it read write (obviously)
- The .../right click menu in Nextcloud has an additional option "Open for editing", which opens the file for editing in the same way clicking used to do.

This also reduces the load on the server, as it doesn't have to create the database data to follow every edit, when the file is read only.

Hope you will consider including this in the next release.