### PR TITLE
Changes defaults to open in same tab.

### DIFF
--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -623,7 +623,7 @@ class AppConfig {
      * @return bool
      */
     public function GetSameTab() {
-        return $this->config->getAppValue($this->appName, $this->_sameTab, "false") === "true";
+        return $this->config->getAppValue($this->appName, $this->_sameTab, "true") === "true";
     }
 
     /**


### PR DESCRIPTION
In term of ux, it is confusing for users when it opens in a new tab.

We think it is a better default to keep the doc in the same tab.