### PR TITLE
Form the file url into a complete url.

### DIFF
--- a/lib/documentservice.php
+++ b/lib/documentservice.php
@@ -97,7 +97,12 @@ class DocumentService {
         $isEndConvert = $responceFromConvertService->EndConvert;
 
         if ($isEndConvert !== null && strtolower($isEndConvert) === "true") {
-            return $responceFromConvertService->FileUrl;
+            $fileUrl = $responceFromConvertService->FileUrl;
+            if ( strpos($fileUrl, "http://") !== 0 && strpos($fileUrl, "https://") !== 0 ){
+                $url = parse_url($document_uri);
+                $fileUrl = $url["scheme"]."://".$url['host'].$fileUrl ;
+            }
+            return $fileUrl;
         }
 
         return "";


### PR DESCRIPTION
Check the file url into a complete url to support onlyoffice documentservice behind a reverse proxy with extra parts in url.

For some reasons, I deploy onlyoffice documentserver behind a reverseproxy with extra parts in path, and one item in the config file `/etc/onlyoffice/documentserver/default.json` is modified like this, so that the onlyoffice documentserver is served at `http://192.168.0.28/utils/onlyoffice/` and everything works properly.

```json
{
    "storage":{
        "externalHost": "/utils/onlyoffice"
    }
}
```

However, when it comes to config onlyoffice in nextcloud, an error occurs (I just pick out part of the log that can locate the problem):

```
[onlyoffice] Error: GuzzleHttp\Exception\RequestException: cURL error 3:  (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) at <<closure>>
apps/onlyoffice/lib/documentservice.php line 369 OC\Http\Client\Client->get("/utils/onlyoffi ... x", {timeout: 60})
```

The function `OC\Http\Client\Client->get()` requires a complete link as the param, but in this case, it only gets the `path` part of the url. A browser like chrome knows to get the resource from the same host so it works properly, but this plugin can't handle this case.

So I make it reacts like the browser and forms the file url into a complete url.