### PR TITLE
Avoid early loading through the filesystem app type

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <version>7.1.2</version>
     <namespace>Onlyoffice</namespace>
     <types>
-        <filesystem/>
+        <prevent_group_restriction/>
     </types>
     <documentation>
         <admin>https://api.onlyoffice.com/editors/nextcloud</admin>


### PR DESCRIPTION
This resolves an issue where rendering an error page could have caused to setup the Nextcloud filesystem which then pulls in the ONLYOFFICE app due to the defined filesystem app type. By itself this is not an issue, but in combination with using LDAP as a user backend 

Steps to reproduce:
- setup ldap
- limit ONLYOFFICE to a local and an LDAP group
- Enable the guests app
- Remove the "text" app from the guests whitelist and add "ONLYOFFICE" to it
- Share a folder as a regular user to a guest
- Login as the guest
- The guest triggers the loading of the text/workspace request which is blocked by the guest app

Before:
- The ONLYOFFICE app will check the setup group limitation and will remove the LDAP group as the ldap user backend is not setup yet

After:
- The ONLYOFFICE app is not loaded that early and will keep the group setting in place