### PR TITLE
Make GetGlobalTemplates faster when template dir is empty

### DIFF
--- a/lib/templatemanager.php
+++ b/lib/templatemanager.php
@@ -69,8 +69,10 @@ class TemplateManager {
         $templateDir = self::GetGlobalTemplateDir();
 
         if (!empty($mimetype)) {
-            $templatesList = $templateDir->searchByMime($mimetype);
-
+            $templatesList = $templateDir->getDirectoryListing();
+            if (is_array($templatesList) && count($templatesList) > 0) {
+                $templatesList = $templateDir->searchByMime($mimetype);
+            }
         } else {
             $templatesList = $templateDir->getDirectoryListing();
         }


### PR DESCRIPTION
If the template directory is empty, we can avoid calling `$dir->searchByMime()` which triggers a heavy request to the `filecache` table.