### PR TITLE
Use proper methods to fetch language/locale code

### DIFF
--- a/controller/editorapicontroller.php
+++ b/controller/editorapicontroller.php
@@ -294,8 +294,8 @@ class EditorApiController extends OCSController {
             ],
             "documentType" => $format["type"],
             "editorConfig" => [
-                "lang" => str_replace("_", "-", \OC::$server->getL10NFactory("")->get("")->getLanguageCode()),
-                "region" => str_replace("_", "-", \OC::$server->getL10NFactory("")->findLocale())
+                "lang" => str_replace("_", "-", \OC::$server->getL10NFactory()->get("onlyoffice")->getLanguageCode()),
+                "region" => str_replace("_", "-", \OC::$server->getL10NFactory()->get("onlyoffice")->getLocaleCode())
             ]
         ];
 


### PR DESCRIPTION
Otherwise obtaining the locale will not use the users language as a possible fallback. This can be reproduced on public share links where usually the browser language is taken as a reference for non-logged in users. Before this change the locale would always have taken the fallback if `en_US`: https://github.com/nextcloud/server/blob/7215148a242815a5064ce5d00a387c634dc936f3/lib/private/L10N/Factory.php#L275-L307