### PR TITLE
Add option to disable macros

### DIFF
--- a/controller/editorapicontroller.php
+++ b/controller/editorapicontroller.php
@@ -646,6 +646,11 @@ class EditorApiController extends OCSController {
             $params["editorConfig"]["customization"]["toolbarNoTabs"] = true;
         }
 
+        //default is true
+        if($this->config->GetCustomizationMacros() === false) {
+            $params["editorConfig"]["customization"]["macros"] = false;
+        }
+
 
         /* from system config */
 

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -126,6 +126,7 @@ class SettingsController extends Controller {
             "toolbarNoTabs" => $this->config->GetCustomizationToolbarNoTabs(),
             "successful" => $this->config->SettingsAreSuccessful(),
             "watermark" => $this->config->GetWatermarkSettings(),
+            "macros" => $this->config->GetCustomizationMacros(),
             "tagsEnabled" => App::isEnabled("systemtags"),
             "reviewDisplay" => $this->config->GetCustomizationReviewDisplay(),
             "templates" => $this->GetGlobalTemplates()
@@ -200,6 +201,7 @@ class SettingsController extends Controller {
      * @param bool $forcesave - forcesave
      * @param bool $help - display help
      * @param bool $toolbarNoTabs - display toolbar tab
+     * @param bool $macros - run document macros
      * @param string $reviewDisplay - review viewing mode
      *
      * @return array
@@ -216,6 +218,7 @@ class SettingsController extends Controller {
                                     $forcesave,
                                     $help,
                                     $toolbarNoTabs,
+                                    $macros,
                                     $reviewDisplay
                                     ) {
 
@@ -231,6 +234,7 @@ class SettingsController extends Controller {
         $this->config->SetCustomizationForcesave($forcesave);
         $this->config->SetCustomizationHelp($help);
         $this->config->SetCustomizationToolbarNoTabs($toolbarNoTabs);
+        $this->config->SetCustomizationMacros($macros);
         $this->config->SetCustomizationReviewDisplay($reviewDisplay);
 
         return [

--- a/js/settings.js
+++ b/js/settings.js
@@ -202,6 +202,7 @@
             var forcesave = $("#onlyofficeForcesave").is(":checked");
             var help = $("#onlyofficeHelp").is(":checked");
             var toolbarNoTabs = $("#onlyofficeToolbarNoTabs").is(":checked");
+            var macros = $("#onlyofficeMacros").is(":checked");
             var reviewDisplay = $("input[type='radio'][name='reviewDisplay']:checked").attr("id").replace("onlyofficeReviewDisplay_", "");
 
             $.ajax({
@@ -220,6 +221,7 @@
                     forcesave: forcesave,
                     help: help,
                     toolbarNoTabs: toolbarNoTabs,
+                    macros: macros,
                     reviewDisplay: reviewDisplay
                 },
                 success: function onSuccess(response) {

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -278,6 +278,13 @@ class AppConfig {
     public $_customization_goback = "customization_goback";
 
     /**
+     * The config key for the macros
+     *
+     * @var string
+     */
+    public $_customizationMacros = "customization_macros";
+
+    /**
      * @param string $AppName - application name
      */
     public function __construct($AppName) {
@@ -1090,6 +1097,25 @@ class AppConfig {
         return $result;
     }
 
+    /**
+     * Save macros setting
+     *
+     * @param bool $value - enable macros
+     */
+    public function SetCustomizationMacros($value) {
+        $this->logger->info("Set macros enabled: " . json_encode($value), ["app" => $this->appName]);
+
+        $this->config->setAppValue($this->appName, $this->_customizationMacros, json_encode($value));
+    }
+
+    /**
+     * Get macros setting
+     *
+     * @return bool
+     */
+    public function GetCustomizationMacros() {
+        return $this->config->getAppValue($this->appName, $this->_customizationMacros, "true") === "true";
+    }
 
     /**
      * Additional data about formats

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -199,6 +199,12 @@
         <label for="onlyofficeToolbarNoTabs"><?php p($l->t("Display monochrome toolbar header")) ?></label>
     </p>
 
+    <p>
+        <input type="checkbox" class="checkbox" id="onlyofficeMacros"
+            <?php if ($_["macros"]) { ?>checked="checked"<?php } ?> />
+        <label for="onlyofficeMacros"><?php p($l->t("Run document macros")) ?></label>
+    </p>
+
     <p class="onlyoffice-header">
         <?php p($l->t("Review mode for viewing")) ?>
     </p>


### PR DESCRIPTION
I've added an option to the settings which is returned in the editor config to disable [macros](https://api.onlyoffice.com/editors/config/editor/customization#macros).

Translations are missing one string: 'Run document macros'