### PR TITLE
Use fixed positioning for the inline frame

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -119,8 +119,8 @@
                 OCA.Files.Sidebar.close();
             }
 
-            var scrollTop = $(window).scrollTop();
-            $(OCA.Onlyoffice.frameSelector).css("top", scrollTop);
+            $(OCA.Onlyoffice.frameSelector).css("top", "50px");
+            $(OCA.Onlyoffice.frameSelector).css("position", "fixed");
 
             OCA.Onlyoffice.folderUrl = location.href;
             window.history.pushState(null, null, url);


### PR DESCRIPTION
There may be conditions where the scroll position changes in the background during the loading of the document, which then leads to the ONLYOFFICE frame being out of position and the file list becoming visible. In order to avoid such issues it would be better to use a fixed positioning for the inline iframe.

