### PR TITLE
Changes the menu entry for docx

### DIFF
--- a/controller/editorapicontroller.php
+++ b/controller/editorapicontroller.php
@@ -396,7 +396,7 @@ class EditorApiController extends OCSController {
 
             switch ($params["documentType"]) {
                 case "word":
-                    $createName = $this->trans->t("New document") . ".docx";
+                    $createName = $this->trans->t("New text document") . ".docx";
                     break;
                 case "cell":
                     $createName = $this->trans->t("New spreadsheet") . ".xlsx";


### PR DESCRIPTION
We realized with our users that when the apps Text and ONLYOFFICE are installed in parallel, this is a bit confusing.

You can see a screenshot here, in french:
https://forge.liiib.re/indiehost/tech/plateforme/-/issues/217#note_9733

So we propose this change.

In relation to this change in [Text app](https://github.com/nextcloud/text/pull/2292).