### PR TITLE
Only call "require_once" if classes don't exist yet.

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -87,10 +87,18 @@ class Application extends App implements IBootstrap {
     }
 
     public function register(IRegistrationContext $context): void {
-        require_once __DIR__ . "/../3rdparty/jwt/BeforeValidException.php";
-        require_once __DIR__ . "/../3rdparty/jwt/ExpiredException.php";
-        require_once __DIR__ . "/../3rdparty/jwt/SignatureInvalidException.php";
-        require_once __DIR__ . "/../3rdparty/jwt/JWT.php";
+        if (!class_exists('\\Firebase\\JWT\\BeforeValidException')) {
+            require_once __DIR__ . "/../3rdparty/jwt/BeforeValidException.php";
+        }
+        if (!class_exists('\\Firebase\\JWT\\ExpiredException')) {
+            require_once __DIR__ . "/../3rdparty/jwt/ExpiredException.php";
+        }
+        if (!class_exists('\\Firebase\\JWT\\SignatureInvalidException')) {
+            require_once __DIR__ . "/../3rdparty/jwt/SignatureInvalidException.php";
+        }
+        if (!class_exists('\\Firebase\\JWT\\JWT')) {
+            require_once __DIR__ . "/../3rdparty/jwt/JWT.php";
+        }
 
         $context->registerService("L10N", function (ContainerInterface $c) {
             return $c->get("ServerContainer")->getL10N($c->get("AppName"));


### PR DESCRIPTION
If another app is loaded before and also loads the JWT classes through
"require_once", loading them again here will fail because the name is
already defined.

Signed-off-by: Joachim Bauch <bauch@struktur.de>