### PR TITLE
correct bug for opening in new tab - fixes #652

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -165,7 +165,7 @@
         var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
         var fileId = context.fileId || fileInfoModel.id;
 
-        OCA.Onlyoffice.OpenEditor(fileId, context.dir, fileName, 0, (OCA.Onlyoffice.setting.sameTab ? null : document));
+        OCA.Onlyoffice.OpenEditor(fileId, context.dir, fileName, 0, (OCA.Onlyoffice.setting.sameTab ? document : null));
 
         OCA.Onlyoffice.context = context;
         OCA.Onlyoffice.context.fileName = fileName;


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/ONLYOFFICE/onlyoffice-nextcloud/commit/948c9f9f2da4adbdde92040444f3aebf410a9ed0 that makes the sameTab setting inverted and opens documents in the same tab, instead of a new one.