### PR TITLE
Ensure upgrade works for postgres database users

### DIFF
--- a/lib/Migration/Version070400Date20220607111111.php
+++ b/lib/Migration/Version070400Date20220607111111.php
@@ -73,7 +73,7 @@ class Version070400Date20220607111111 extends SimpleMigrationStep {
 				'default' => 0,
 			]);
 			$table->setPrimaryKey(['id']);
-			$table->addUniqueIndex(['share_id'], 'share_id_index');
+			$table->addUniqueIndex(['share_id'], 'op_share_id_index');
 		}
 
 		return $schema;


### PR DESCRIPTION
Resolves #661. In postgres index names must be unique database wide and share_id_index is in use by Nextcloud core.