### PR TITLE
Add unknown-author feature

### DIFF
--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -753,8 +753,8 @@ class EditorController extends Controller {
             $versionId = $version->getRevisionId();
 
             $author = FileVersions::getAuthor($ownerId, $fileId, $versionId);
-            $authorId = $author !== null ? $author["id"] : $ownerId;
-            $authorName = $author !== null ? $author["name"] : $owner->getDisplayName();
+            $authorId = $author !== null ? $author["id"] : $this->config->GetUnknownAuthor();
+            $authorName = $author !== null ? $author["name"] : $this->config->GetUnknownAuthor();
 
             $historyItem["user"] = [
                 "id" => $this->buildUserId($authorId),

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -122,6 +122,7 @@ class SettingsController extends Controller {
             "chat" => $this->config->GetCustomizationChat(),
             "compactHeader" => $this->config->GetCustomizationCompactHeader(),
             "feedback" => $this->config->GetCustomizationFeedback(),
+            "unknownAuthor" => $this->config->GetUnknownAuthor(),
             "forcesave" => $this->config->GetCustomizationForcesave(),
             "help" => $this->config->GetCustomizationHelp(),
             "toolbarNoTabs" => $this->config->GetCustomizationToolbarNoTabs(),
@@ -201,6 +202,7 @@ class SettingsController extends Controller {
      * @param bool $chat - display chat
      * @param bool $compactHeader - display compact header
      * @param bool $feedback - display feedback
+     * @param string $unknownAuthor - unknownAuthor display name
      * @param bool $forcesave - forcesave
      * @param bool $help - display help
      * @param bool $toolbarNoTabs - display toolbar tab
@@ -218,6 +220,7 @@ class SettingsController extends Controller {
                                     $chat,
                                     $compactHeader,
                                     $feedback,
+                                    $unknownAuthor,
                                     $forcesave,
                                     $help,
                                     $toolbarNoTabs,
@@ -235,6 +238,7 @@ class SettingsController extends Controller {
         $this->config->SetCustomizationChat($chat);
         $this->config->SetCustomizationCompactHeader($compactHeader);
         $this->config->SetCustomizationFeedback($feedback);
+        $this->config->SetUnknownAuthor($unknownAuthor);
         $this->config->SetCustomizationForcesave($forcesave);
         $this->config->SetCustomizationHelp($help);
         $this->config->SetCustomizationToolbarNoTabs($toolbarNoTabs);

--- a/js/settings.js
+++ b/js/settings.js
@@ -200,6 +200,7 @@
             var chat = $("#onlyofficeChat").is(":checked");
             var compactHeader = $("#onlyofficeCompactHeader").is(":checked");
             var feedback = $("#onlyofficeFeedback").is(":checked");
+            var onlyofficeUnknownAuthor = ($("#onlyofficeUnknownAuthor:visible").val()).trim();
             var forcesave = $("#onlyofficeForcesave").is(":checked");
             var help = $("#onlyofficeHelp").is(":checked");
             var toolbarNoTabs = $("#onlyofficeToolbarNoTabs").is(":checked");
@@ -220,6 +221,7 @@
                     chat: chat,
                     compactHeader: compactHeader,
                     feedback: feedback,
+                    unknownAuthor: onlyofficeUnknownAuthor,
                     forcesave: forcesave,
                     help: help,
                     toolbarNoTabs: toolbarNoTabs,

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -131,6 +131,13 @@ class AppConfig {
     private $_versionHistory = "versionHistory";
 
     /**
+     * Display name of the unknown author
+     *
+     * @var string
+     */
+    private $_unknownAuthor = "unknownAuthor";
+
+    /**
      * The config key for the chat display setting
      *
      * @var string
@@ -1094,6 +1101,25 @@ class AppConfig {
         }
 
         return 100*1024*1024;
+    }
+
+    /**
+     * Save unknownAuthor setting
+     *
+     * @param string $value - unknownAuthor
+     */
+    public function SetUnknownAuthor($value) {
+        $this->logger->info("Set unknownAuthor: " . trim($value), ["app" => $this->appName]);
+        $this->config->setAppValue($this->appName, $this->_unknownAuthor, trim($value));
+    }
+
+    /**
+     * Get unknownAuthor setting
+     *
+     * @return bool
+     */
+    public function GetUnknownAuthor() {
+        return $this->config->getAppValue($this->appName, $this->_unknownAuthor, "< no-data >");
     }
 
     /**

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -165,6 +165,9 @@
         <a target="_blank" class="icon-info svg" title="" href="https://api.onlyoffice.com/editors/config/editor/customization" data-original-title="<?php p($l->t("View details")) ?>"></a>
     </h2>
 
+    <p><?php p($l->t("Unknown author display name")) ?></p>
+    <p><input id="onlyofficeUnknownAuthor" value="<?php p($_["unknownAuthor"]) ?>" placeholder="<no-data>" type="text"></p>
+
     <p>
         <input type="checkbox" class="checkbox" id="onlyofficeForcesave"
             <?php if ($_["forcesave"]) { ?>checked="checked"<?php } ?> />


### PR DESCRIPTION
Feature that allows administrator set what should be displayed in version history if the author of version is unknown.

It is more informative than displaying the owner of file as the author of all changes made without information about the author.