### PR TITLE
Fix sending notifications for mentions with big length

### DIFF
--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -448,8 +448,6 @@ class EditorController extends Controller {
 
         $recipientIds = [];
         foreach ($emails as $email) {
-            $substrToDelete = "+" . $email . " ";
-            $comment = str_replace($substrToDelete, "", $comment);
             $recipients = $this->userManager->getByEmail($email);
             foreach ($recipients as $recipient) {
                 $recipientId = $recipient->getUID(); 
@@ -479,6 +477,12 @@ class EditorController extends Controller {
             return ["error" => $this->trans->t("Failed to send notification")];
         }
 
+        foreach ($emails as $email) {
+            $substrToDelete = "+" . $email . " ";
+            $comment = str_replace($substrToDelete, "", $comment);
+        }
+
+        // change to mb_strlen and mb_substr when Notification.php fixed in #35016 nextcloud/server
         if (strlen($comment) > 64) {
             $comment = substr($comment, 0, 61) . "...";
         }

--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -448,6 +448,8 @@ class EditorController extends Controller {
 
         $recipientIds = [];
         foreach ($emails as $email) {
+            $substrToDelete = "+" . $email . " ";
+            $comment = str_replace($substrToDelete, "", $comment);
             $recipients = $this->userManager->getByEmail($email);
             foreach ($recipients as $recipient) {
                 $recipientId = $recipient->getUID(); 
@@ -475,6 +477,10 @@ class EditorController extends Controller {
         if (isset($error)) {
             $this->logger->error("Mention: $fileId $error", ["app" => $this->appName]);
             return ["error" => $this->trans->t("Failed to send notification")];
+        }
+
+        if (strlen($comment) > 64) {
+            $comment = substr($comment, 0, 61) . "...";
         }
 
         $notificationManager = \OC::$server->getNotificationManager();


### PR DESCRIPTION
If you try to mention someone in comment and write a message longer than 64 symbols (including "+email@example.com "), then there is no notification being send.

This PR fixes this issue by removing the emails from incoming comment, and if comment is still longer than 64 symbols, then it converts to 61 first symbols and "..." instead.