### PR TITLE
Add fix for custom ports

### DIFF
--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -498,6 +498,10 @@ class AppConfig {
             {
                 $this->logger->debug("Replace url from $from to $documentServerUrl", ["app" => $this->appName]);
                 $url = str_replace($from, $documentServerUrl, $url);
+                $parsedUrl = parse_url($from);
+                $fromNoPort = $parsedUrl["scheme"] . "://" . $parsedUrl["host"];
+                $this->logger->debug("Replace url from $fromNoPort to $documentServerUrl", ["app" => $this->appName]);
+                $url = str_replace($fromNoPort, $documentServerUrl, $url);
             }
         }
 


### PR DESCRIPTION
Currently if you have a setup like this in Nextcloud and OnlyOffice (such as with Docker):

ONLYOFFICE Docs address: `https://onlyoffice.mydomain.com:1111/`
ONLYOFFICE Docs address for internal requests from the server: `http://onlyoffice/`
Server address for internal requests from ONLYOFFICE Docs: `http://nextcloud/`

You cannot save documents. This is because OnlyOffice sends a request to Nextcloud with a JSON body that contains `https://onlyoffice.mydomain.com/` instead of `https://onlyoffice.mydomain.com:1111/`. This might be why there are a number of reports out there of the cannot save files still floating around.

I'm not sure if this is the *best* way to fix this, but basically this forces a replacement on the URL without a port to cover off on the scenario.