### PR TITLE
fileType for history data for editors 5.0, 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Changed
 - anonymous without configuring file protection, chat and without the possibility of mentioning
+- fileType to history data
 
 ## 7.8.0
 ## Added

--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -965,8 +965,11 @@ class EditorController extends Controller {
             $fileUrl = $this->getUrl($file, $user, null, $version);
         }
         $key = DocumentService::GenerateRevisionId($key);
+        $fileName = $file->getName();
+        $ext = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
 
         $result = [
+            "fileType" => $ext,
             "url" => $fileUrl,
             "version" => $version,
             "key" => $key
@@ -986,6 +989,7 @@ class EditorController extends Controller {
             $prevVersionUrl = $this->getUrl($file, $user, null, $version - 1);
 
             $result["previous"] = [
+                "fileType" => $ext,
                 "key" => $prevVersionKey,
                 "url" => $prevVersionUrl
             ];


### PR DESCRIPTION
Added `fileType` to history data for editors 5.0 and 6.0