### PR TITLE
Added theme-system and theme-contrast-dark

### DIFF
--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -923,14 +923,17 @@ class AppConfig {
      * @return string
      */
     public function GetCustomizationTheme() {
-        $value = $this->config->getAppValue($this->appName, $this->_customizationTheme, "theme-classic-light");
-        if ($value === "theme-light") {
-            return "theme-light";
+        $value = $this->config->getAppValue($this->appName, $this->_customizationTheme, "theme-system");
+        switch ($value) {
+            case "theme-system":
+            case "theme-light":
+            case "theme-classic-light":
+            case "theme-dark":
+            case "theme-contrast-dark":
+                return $value;
+                break;
         }
-        if ($value === "theme-dark") {
-            return "theme-dark";
-        }
-        return "theme-classic-light";
+        return "theme-system";
     }
 
     /**

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -241,6 +241,13 @@
     <div class="onlyoffice-tables">
         <div>
             <input type="radio" class="radio"
+                id="onlyofficeTheme_theme-system"
+                name="theme"
+                <?php if ($_["theme"] === "theme-system") { ?>checked="checked"<?php } ?> />
+            <label for="onlyofficeTheme_theme-system"><?php p($l->t("Same as system")) ?></label>
+        </div>
+        <div>
+            <input type="radio" class="radio"
                 id="onlyofficeTheme_theme-light"
                 name="theme"
                 <?php if ($_["theme"] === "theme-light") { ?>checked="checked"<?php } ?> />
@@ -259,6 +266,13 @@
                 name="theme"
                 <?php if ($_["theme"] === "theme-dark") { ?>checked="checked"<?php } ?> />
             <label for="onlyofficeTheme_theme-dark"><?php p($l->t("Dark")) ?></label>
+        </div>
+        <div>
+            <input type="radio" class="radio"
+                id="onlyofficeTheme_theme-contrast-dark"
+                name="theme"
+                <?php if ($_["theme"] === "theme-contrast-dark") { ?>checked="checked"<?php } ?> />
+            <label for="onlyofficeTheme_theme-constrast-dark"><?php p($l->t("Contrast dark")) ?></label>
         </div>
     </div>
 


### PR DESCRIPTION
As OnlyOffice now includes a theme to match the system settings and a high contrast dark theme, this PR adds support for both. Additionally, it:
- Shortens the validation code in `appconfig.php`
- Defaults to `theme-system` if no options has been configured

Solves https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/823