### PR TITLE
fixed GetEditorsCheckInterval()

### DIFF
--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -1288,12 +1288,12 @@ class AppConfig {
      * @return int
      */
     public function GetEditorsCheckInterval() {
-        $interval = (integer)$this->GetSystemValue($this->_editors_check_interval);
+        $interval = $this->GetSystemValue($this->_editors_check_interval);
 
-        if (empty($interval)) {
+        if (empty($interval) && $interval !== 0) {
             $interval = 60*60*24;
         }
-        return $interval;
+        return (integer)$interval;
     }
 
     /**


### PR DESCRIPTION
Fixed `GetEditorsCheckInterval()`. `0` is a valid value now.