### PR TITLE
use proper path on node api when calling the view

### DIFF
--- a/lib/fileversions.php
+++ b/lib/fileversions.php
@@ -24,6 +24,7 @@ use OC\Files\View;
 use OC\User\Database;
 
 use OCP\Files\FileInfo;
+use OCP\Files\IRootFolder;
 use OCP\IUser;
 
 use OCA\Files_Sharing\External\Storage as SharingExternalStorage;
@@ -230,8 +231,10 @@ class FileVersions {
         }
 
         $changesInfo = $view->getFileInfo($changesPath);
-        $changes = new File($view->getRoot(), $view, $changesPath, $changesInfo);
+        $rootView = \OC::$server->get(View::class);
+        $root = \OC::$server->get(IRootFolder::class);
 
+        $changes = new File($root, $rootView, $view->getAbsolutePath($changesPath), $changesInfo);
         \OC::$server->getLogger()->debug("getChangesFile: $fileId for $ownerId get changes $changesPath", ["app" => self::$appName]);
 
         return $changes;


### PR DESCRIPTION
Attempts to call node api in `getChangesFile()` resulted in an [error](https://forum.onlyoffice.com/t/viewing-file-history-does-not-work-in-nextcloud/5105). The solution is taken from the [NextCloud repository](https://github.com/nextcloud/server/pull/36774/files#diff-7ed74baefb94f2f93809c92d12948f3b4f276dafca8a57c621def5668f670e9a).