### PR TITLE
if editors are available only for any group, don't add scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##
 ## Changed
 - fix author in group folder
+- fixed guest redirect when limiting the app to groups
 - fixed error display in the mobile application
 - Nextcloud v25 is no longer supported
 

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -1076,7 +1076,7 @@ class AppConfig {
 
         $groups = $this->getLimitGroups();
         // no group set -> all users are allowed
-        if (count($groups) === 0) {
+        if (empty($groups)) {
             return true;
         }
 

--- a/lib/listeners/filesharinglistener.php
+++ b/lib/listeners/filesharinglistener.php
@@ -75,7 +75,8 @@ class FileSharingListener implements IEventListener {
         }
 
         if (!empty($this->appConfig->getDocumentServerUrl())
-            && $this->appConfig->settingsAreSuccessful()) {
+            && $this->appConfig->settingsAreSuccessful()
+            && empty($this->appConfig->getLimitGroups())) {
             Util::addScript("onlyoffice", "main");
 
             if ($this->appConfig->getSameTab()) {


### PR DESCRIPTION
do not add scripts to share docs if the application is available to certain groups