### PR TITLE
Feature/cron checker setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - advanced access rights for talk files and share links
 - reference data from coediting
 - selecting a document to combine from the storage
+- setting for disable editors cron check
 
 ## 7.9.4
 ## Changed

--- a/controller/joblistcontroller.php
+++ b/controller/joblistcontroller.php
@@ -90,7 +90,7 @@ class JobListController extends Controller {
      *
      */
     private function checkEditorsCheckJob() {
-        if ($this->config->getCronChecker()) {
+        if (!$this->config->getCronChecker()) {
             $this->removeJob(EditorsCheck::class);
             return;
         }

--- a/controller/joblistcontroller.php
+++ b/controller/joblistcontroller.php
@@ -90,6 +90,10 @@ class JobListController extends Controller {
      *
      */
     private function checkEditorsCheckJob() {
+        if ($this->config->getCronChecker()) {
+            $this->removeJob(EditorsCheck::class);
+            return;
+        }
         if ($this->config->getEditorsCheckInterval() > 0) {
             $this->addJob(EditorsCheck::class);
         } else {

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -117,6 +117,7 @@ class SettingsController extends Controller {
             "sameTab" => $this->config->getSameTab(),
             "preview" => $this->config->getPreview(),
             "advanced" => $this->config->getAdvanced(),
+            "cronChecker" => $this->config->getCronChecker(),
             "versionHistory" => $this->config->getVersionHistory(),
             "protection" => $this->config->getProtection(),
             "limitGroups" => $this->config->getLimitGroups(),
@@ -203,6 +204,7 @@ class SettingsController extends Controller {
      * @param bool $sameTab - open in the same tab
      * @param bool $preview - generate preview files
      * @param bool $advanced - use advanced tab
+     * @param bool $cronChecker - disable cron checker
      * @param bool $versionHistory - keep version history
      * @param array $limitGroups - list of groups
      * @param bool $chat - display chat
@@ -221,6 +223,7 @@ class SettingsController extends Controller {
         $sameTab,
         $preview,
         $advanced,
+        $cronChecker,
         $versionHistory,
         $limitGroups,
         $chat,
@@ -238,6 +241,7 @@ class SettingsController extends Controller {
         $this->config->setSameTab($sameTab);
         $this->config->setPreview($preview);
         $this->config->setAdvanced($advanced);
+        $this->config->setCronChecker($cronChecker);
         $this->config->setVersionHistory($versionHistory);
         $this->config->setLimitGroups($limitGroups);
         $this->config->setCustomizationChat($chat);

--- a/js/settings.js
+++ b/js/settings.js
@@ -198,6 +198,7 @@
             var sameTab = $("#onlyofficeSameTab").is(":checked");
             var preview = $("#onlyofficePreview").is(":checked");
             var advanced = $("#onlyofficeAdvanced").is(":checked");
+            var cronChecker = $("#onlyofficeCronChecker").is(":checked");
             var versionHistory = $("#onlyofficeVersionHistory").is(":checked");
 
             var limitGroupsString = $("#onlyofficeGroups").prop("checked") ? $("#onlyofficeLimitGroups").val() : "";
@@ -221,6 +222,7 @@
                     sameTab: sameTab,
                     preview: preview,
                     advanced: advanced,
+                    cronChecker: cronChecker,
                     versionHistory: versionHistory,
                     limitGroups: limitGroups,
                     chat: chat,

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -142,6 +142,6 @@ OC.L10N.register(
     "Share link": "Общий доступ по ссылке",
     "conversation": "беседа",
     "Select file to combine" : "Выбрать файл для объединения",
-    "Disable cron check (scheduled task of checking connection to the editors)": "Отключить проверку Cron (запланированное задание для проверки доступности редакторов)"
+    "Enable background connection check to the editors": "Включить фоновую проверку подключения к редакторам"
 },
 "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);");

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -141,6 +141,7 @@ OC.L10N.register(
     "View settings": "Посмотреть настройки",
     "Share link": "Общий доступ по ссылке",
     "conversation": "беседа",
-    "Select file to combine" : "Выбрать файл для объединения"
+    "Select file to combine" : "Выбрать файл для объединения",
+    "Disable cron check (scheduled task of checking connection to the editors)": "Отключить проверку Cron (запланированное задание для проверки доступности редакторов)"
 },
 "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);");

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -139,6 +139,7 @@
     "View settings": "Посмотреть настройки",
     "Share link" : "Общий доступ по ссылке",
     "conversation": "беседа",
-    "Select file to combine" : "Выбрать файл для объединения"
+    "Select file to combine" : "Выбрать файл для объединения",
+    "Disable cron check (scheduled task of checking connection to the editors)": "Отключить проверку Cron (запланированное задание для проверки доступности редакторов)"
 },"pluralForm" :"nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);"
 }

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -140,6 +140,6 @@
     "Share link" : "Общий доступ по ссылке",
     "conversation": "беседа",
     "Select file to combine" : "Выбрать файл для объединения",
-    "Disable cron check (scheduled task of checking connection to the editors)": "Отключить проверку Cron (запланированное задание для проверки доступности редакторов)"
+    "Enable background connection check to the editors": "Включить фоновую проверку подключения к редакторам"
 },"pluralForm" :"nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);"
 }

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -724,7 +724,7 @@ class AppConfig {
      * @return bool
      */
     public function getCronChecker() {
-        return $this->config->getAppValue($this->appName, $this->_cronChecker, "false") === "true";
+        return $this->config->getAppValue($this->appName, $this->_cronChecker, "true") !== "false";
     }
 
     /**
@@ -733,7 +733,7 @@ class AppConfig {
      * @param bool $value - cronChecker
      */
     public function setCronChecker($value) {
-        $this->logger->info("Set disable cron checker: " . json_encode($value), ["app" => $this->appName]);
+        $this->logger->info("Set cron checker: " . json_encode($value), ["app" => $this->appName]);
 
         $this->config->setAppValue($this->appName, $this->_cronChecker, json_encode($value));
     }

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -123,6 +123,13 @@ class AppConfig {
     private $_advanced = "advanced";
 
     /**
+     * The config key for the cronChecker
+     *
+     * @var string
+     */
+    private $_cronChecker = "cronChecker";
+
+    /**
      * The config key for the keep versions history
      *
      * @var string
@@ -709,6 +716,26 @@ class AppConfig {
         $this->logger->info("Set advanced: " . json_encode($value), ["app" => $this->appName]);
 
         $this->config->setAppValue($this->appName, $this->_advanced, json_encode($value));
+    }
+
+    /**
+     * Get cron checker setting
+     *
+     * @return bool
+     */
+    public function getCronChecker() {
+        return $this->config->getAppValue($this->appName, $this->_cronChecker, "false") === "true";
+    }
+
+    /**
+     * Save cron checker setting
+     *
+     * @param bool $value - cronChecker
+     */
+    public function setCronChecker($value) {
+        $this->logger->info("Set disable cron checker: " . json_encode($value), ["app" => $this->appName]);
+
+        $this->config->setAppValue($this->appName, $this->_cronChecker, json_encode($value));
     }
 
     /**

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -132,7 +132,7 @@ if ($_["tagsEnabled"]) {
     <p>
         <input type="checkbox" class="checkbox" id="onlyofficeCronChecker"
             <?php if ($_["cronChecker"]) { ?>checked="checked"<?php } ?> />
-        <label for="onlyofficeCronChecker"><?php p($l->t("Disable cron check (scheduled task of checking connection to the editors)")) ?></label>
+        <label for="onlyofficeCronChecker"><?php p($l->t("Enable background connection check to the editors")) ?></label>
     </p>
 
     <p class="onlyoffice-header"><?php p($l->t("The default application for opening the format")) ?></p>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -129,6 +129,12 @@ if ($_["tagsEnabled"]) {
         <button id="onlyofficeClearVersionHistory" class="button"><?php p($l->t("Clear")) ?></button>
     </p>
 
+    <p>
+        <input type="checkbox" class="checkbox" id="onlyofficeCronChecker"
+            <?php if ($_["cronChecker"]) { ?>checked="checked"<?php } ?> />
+        <label for="onlyofficeCronChecker"><?php p($l->t("Disable cron check (scheduled task of checking connection to the editors)")) ?></label>
+    </p>
+
     <p class="onlyoffice-header"><?php p($l->t("The default application for opening the format")) ?></p>
     <div class="onlyoffice-exts">
         <?php foreach ($_["formats"] as $format => $setting) { ?>


### PR DESCRIPTION
A setting has been added to the plugin interface to disable the cron task `EditorsCheck` that checks the availability of editors.