### PR TITLE
fix: unnecessary debug message deleted

### DIFF
--- a/js/listener.js
+++ b/js/listener.js
@@ -82,7 +82,6 @@
     };
 
     OCA.Onlyoffice.onRequestReferenceSource = function (referenceSourceMimes) {
-        console.log(referenceSourceMimes);
         OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, "Select data source"),
             $(OCA.Onlyoffice.frameSelector)[0].contentWindow.OCA.Onlyoffice.editorReferenceSource,
             false,


### PR DESCRIPTION
delete `console.log();` from `listener.js`