### PR TITLE
fix: added check for the case when there is no context.$file

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -166,7 +166,7 @@
 
     OCA.Onlyoffice.FileClick = function (fileName, context) {
         var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
-        var fileId = context.fileId || context.$file[0].dataset.id || fileInfoModel.id;
+        var fileId = context.fileId || context.$file && context.$file[0].dataset.id || fileInfoModel.id;
         var winEditor = !fileInfoModel && !OCA.Onlyoffice.setting.sameTab ? document : null;
 
         OCA.Onlyoffice.OpenEditor(fileId, context.dir, fileName, 0, winEditor);
@@ -178,9 +178,10 @@
     OCA.Onlyoffice.FileConvertClick = function (fileName, context) {
         var fileInfoModel = context.fileInfoModel || context.fileList.getModelForFile(fileName);
         var fileList = context.fileList;
+        var fileId = context.$file ? context.$file[0].dataset.id : fileInfoModel.id;
 
         var convertData = {
-            fileId: context.$file[0].dataset.id || fileInfoModel.id
+            fileId: fileId
         };
 
         if ($("#isPublic").val()) {


### PR DESCRIPTION
added check for the case when there is no `context.$file`