### PR TITLE
GetEditorsCheckInterval now check system value properly.

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -1336,7 +1336,7 @@ class AppConfig {
     public function getEditorsCheckInterval() {
         $interval = $this->getSystemValue($this->_editors_check_interval);
 
-        if (empty($interval) && $interval !== 0) {
+        if (empty($interval) && (!($interval === '0'))) {
             $interval = 60 * 60 * 24;
         }
         return (integer)$interval;


### PR DESCRIPTION
# editors_check_interval check fix

## Introduction

This aims to fix: https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/864 bug.

Specifically the part where the `editors_check_interval` value keeps getting ignored.

I think that the setting is coming as an string type and that's why it wasn't checked properly.

## How to turn this on

```
php occ config:system:set onlyoffice editors_check_interval --value=0
```
given that:
```
php occ config:app:set onlyoffice editors_check_interval --value=0
```
won't be read at all by the current code.

## Debug help

Note that I have not been able to check this in a cron scenario because I'm not sure how to force that same cron to be run.
Were you to give some clues on how to force the app's cron or whatever triggers the `JobListController.php` controller to do its thing I would double-check this thanks to some debug to the nextcloud.log file.

## About previous code

So the previous when interval was set to 0 it always changed that value to 86400 while ignoring the requested 0 value.