### PR TITLE
editors check interval fix

### DIFF
--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -1325,6 +1325,13 @@ class AppConfig {
      */
     public function getEditorsCheckInterval() {
         $interval = $this->getSystemValue($this->_editors_check_interval);
+        if ($interval !== null && !is_int($interval)) {
+            if (is_string($interval) && !ctype_digit($interval)) {
+                $interval = null;
+            } else {
+                $interval = (integer)$interval;
+            }
+        }
 
         if (empty($interval) && $interval !== 0) {
             $interval = 60 * 60 * 24;


### PR DESCRIPTION
We can set the value of a variable either manually, in `config.php`, or with the `occ` command. Therefore, the parameter value can be of different types. We now check that the `check_interval editors` are of type `string` and that the value is a string, which is usually cast to an `int`.