### PR TITLE
fix: if the user has no groups, then he is not a member of excluded groups

### DIFF
--- a/controller/editorcontroller.php
+++ b/controller/editorcontroller.php
@@ -374,7 +374,7 @@ class EditorController extends Controller {
 
         $excludedGroups = $this->getShareExcludedGroups();
         $isMemberExcludedGroups = true;
-        if (count(array_intersect($currentUserGroups, $excludedGroups)) !== count($currentUserGroups)) {
+        if ((count(array_intersect($currentUserGroups, $excludedGroups)) !== count($currentUserGroups)) || empty($currentUserGroups)) {
             $isMemberExcludedGroups = false;
         }
 
@@ -519,7 +519,7 @@ class EditorController extends Controller {
 
         $excludedGroups = $this->getShareExcludedGroups();
         $isMemberExcludedGroups = true;
-        if (count(array_intersect($currentUserGroups, $excludedGroups)) !== count($currentUserGroups)) {
+        if ((count(array_intersect($currentUserGroups, $excludedGroups)) !== count($currentUserGroups)) || empty($currentUserGroups)) {
             $isMemberExcludedGroups = false;
         }
 


### PR DESCRIPTION
if the user has no groups, then he is not a member of excluded groups