### PR TITLE
Fix #981

### DIFF
--- a/lib/Listeners/WidgetListener.php
+++ b/lib/Listeners/WidgetListener.php
@@ -62,7 +62,7 @@ class WidgetListener implements IEventListener {
         if (!empty($this->appConfig->getDocumentServerUrl())
             && $this->appConfig->settingsAreSuccessful()
             && $this->appConfig->isUserAllowedToUse()) {
-            Util::addScript("onlyoffice", "desktop");
+            Util::addScript("onlyoffice", "onlyoffice-desktop");
         }
     }
 }


### PR DESCRIPTION
The files in the `js/` folder are all named with the prefix `onlyoffice-` and `Util::addScript()` is defined to use the second parameter as the base name of the script to be added. However this is not `desktop` but `onlyoffice-desktop`: 

```
onlyoffice-desktop.js
onlyoffice-desktop.js.map
onlyoffice-directeditor.js
onlyoffice-directeditor.js.map
onlyoffice-editor.js
onlyoffice-editor.js.map
onlyoffice-listener.js
onlyoffice-listener.js.map
onlyoffice-main.js
onlyoffice-main.js.LICENSE.txt
onlyoffice-main.js.map
onlyoffice-settings.js
onlyoffice-settings.js.map
onlyoffice-share.js
onlyoffice-share.js.map
onlyoffice-template.js
onlyoffice-template.js.map
onlyoffice-viewer.js
onlyoffice-viewer.js.map
```