### PR TITLE
OnlyOffice app icons are not highlighted as active in navigation bar

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -1355,6 +1355,9 @@ class EditorController extends Controller {
 
         \OCP\Util::addHeader("meta", ["name" => "apple-touch-fullscreen", "content" => "yes"]);
 
+        $app = $this->appName.'_'.$this->getExt($fileId);
+        \OC::$server->getNavigationManager()->setActiveEntry($app);
+        
         $csp = new ContentSecurityPolicy();
 
         if (preg_match("/^https?:\/\//i", $documentServerUrl)) {
@@ -1367,7 +1370,19 @@ class EditorController extends Controller {
 
         return $response;
     }
-
+    private function getExt($fileId)
+    {
+        $user = $this->userSession->getUser();
+        $userId = null;
+        if (empty($user)) {
+            return '';
+        }
+        $userId = $user->getUID();
+        list($file, $error, $share) = $this->getFile($userId, $fileId);
+        $fileName = $file->getName();
+        $ext = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+        return $ext;
+    }
     /**
      * Print public editor section
      *


### PR DESCRIPTION
Resolves https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/1009