### PR TITLE
Solve OnlyOffice-Nextcloud Connector not working in Nextcloud 30.0  #1020

### DIFF
--- a/templates/editor.php
+++ b/templates/editor.php
@@ -52,7 +52,7 @@ if (!empty($_["directToken"])) {
         data-forceedit="<?php p($_["forceEdit"]) ?>"></div>
 
     <?php if (!empty($_["documentServerUrl"])) { ?>
-        <script nonce="<?php p(base64_encode($_["requesttoken"])) ?>"
+        <script nonce="<?php p($_["cspNonce"]) ?>"
             src="<?php p($_["documentServerUrl"]) ?>web-apps/apps/api/documents/api.js" type="text/javascript"></script>
     <?php } ?>
 


### PR DESCRIPTION
Solving #1020 by using $_["cspNonce"] instead of $_["requesttoken"] to use the right token in <script> tag