### PR TITLE
Nextcloud 31 compatibility and some code cleanup

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -1437,7 +1437,7 @@ class AppConfig {
             }
             return $result;
         } catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Format matrix error", "app" => $this->appName]);
+            $this->logger->error("Format matrix error", ['exception' => $e]);
             return [];
         }
     }

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -1195,7 +1195,7 @@ class AppConfig {
             // group unknown -> error and allow nobody
             $group = \OC::$server->getGroupManager()->get($groupName);
             if ($group === null) {
-                \OC::$server->getLogger()->error("Group is unknown $groupName", ["app" => $this->appName]);
+                \OCP\Log\logger('onlyoffice')->error("Group is unknown $groupName", ["app" => $this->appName]);
                 $this->setLimitGroups(array_diff($groups, [$groupName]));
             } else {
                 if ($group->inGroup($user)) {

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -36,6 +36,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
+use OCA\Onlyoffice\AppInfo\Application;
 
 /**
  * Application configutarion
@@ -43,28 +44,6 @@ use Psr\Log\LoggerInterface;
  * @package OCA\Onlyoffice
  */
 class AppConfig {
-
-    /**
-     * Application name
-     *
-     * @var string
-     */
-    private $appName;
-
-    /**
-     * Config service
-     *
-     * @var IConfig
-     */
-    private $config;
-
-    /**
-     * Logger
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
-
     /**
      * The config key for the demo server
      *
@@ -361,22 +340,16 @@ class AppConfig {
 
     /**
      * The config key for store cache
-     *
-     * @var ICache
      */
-    private $cache;
+    private ICache $cache;
 
-    /**
-     * @param string $AppName - application name
-     */
-    public function __construct($AppName) {
-
-        $this->appName = $AppName;
-
-        $this->config = \OC::$server->getConfig();
-        $this->logger = \OCP\Server::get(LoggerInterface::class);
-        $cacheFactory = \OCP\Server::get(ICacheFactory::class);
-        $this->cache = $cacheFactory->createLocal($this->appName);
+    public function __construct(
+        private string $appName,
+        private IConfig $config,
+        private LoggerInterface $logger,
+        ICacheFactory $cacheFactory,
+    ) {
+        $this->cache = $cacheFactory->createLocal(Application::APP_ID);
     }
 
     /**

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -374,8 +374,8 @@ class AppConfig {
         $this->appName = $AppName;
 
         $this->config = \OC::$server->getConfig();
-        $this->logger = \OC::$server->get(LoggerInterface::class);
-        $cacheFactory = \OC::$server->get(ICacheFactory::class);
+        $this->logger = \OCP\Server::get(LoggerInterface::class);
+        $cacheFactory = \OCP\Server::get(ICacheFactory::class);
         $this->cache = $cacheFactory->createLocal($this->appName);
     }
 

--- a/lib/Controller/JobListController.php
+++ b/lib/Controller/JobListController.php
@@ -79,7 +79,7 @@ class JobListController extends Controller {
     private function addJob($job) {
         if (!$this->jobList->has($job, null)) {
             $this->jobList->add($job);
-            \OC::$server->getLogger()->debug("Job '".$job."' added to JobList.", ["app" => $this->appName]);
+            \OCP\Log\logger('onlyoffice')->debug("Job '".$job."' added to JobList.", ["app" => $this->appName]);
         }
     }
 
@@ -91,7 +91,7 @@ class JobListController extends Controller {
     private function removeJob($job) {
         if ($this->jobList->has($job, null)) {
             $this->jobList->remove($job);
-            \OC::$server->getLogger()->debug("Job '".$job."' removed from JobList.", ["app" => $this->appName]);
+            \OCP\Log\logger('onlyoffice')->debug("Job '".$job."' removed from JobList.", ["app" => $this->appName]);
         }
     }
 

--- a/lib/Cron/EditorsCheck.php
+++ b/lib/Cron/EditorsCheck.php
@@ -127,15 +127,15 @@ class EditorsCheck extends TimedJob {
         $this->appName = $AppName;
         $this->urlGenerator = $urlGenerator;
 
-        $this->logger = \OC::$server->get(LoggerInterface::class);
+        $this->logger = \OCP\Server::get(LoggerInterface::class);
         $this->config = $config;
         $this->trans = $trans;
         $this->crypt = $crypt;
         $this->groupManager = $groupManager;
         $this->setInterval($this->config->getEditorsCheckInterval());
         $this->setTimeSensitivity(IJob::TIME_SENSITIVE);
-        $mailer = \OC::$server->get(IMailer::class);
-        $userManager = \OC::$server->get(IUserManager::class);
+        $mailer = \OCP\Server::get(IMailer::class);
+        $userManager = \OCP\Server::get(IUserManager::class);
         $this->emailManager = new EmailManager($AppName, $trans, $logger, $mailer, $userManager, $urlGenerator);
     }
 

--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -411,7 +411,7 @@ class DocumentService {
                 throw new \Exception($this->trans->t("Mixed Active Content is not allowed. HTTPS address for ONLYOFFICE Docs is required."));
             }
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "Protocol on check error", "app" => self::$appName]);
+            $logger->error("Protocol on check error", ['exception' => $e]);
             return [$e->getMessage(), $version];
         }
 
@@ -421,7 +421,7 @@ class DocumentService {
                 throw new \Exception($this->trans->t("Bad healthcheck status"));
             }
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "healthcheckRequest on check error", "app" => self::$appName]);
+            $logger->error("healthcheckRequest on check error", ['exception' => $e]);
             return [$e->getMessage(), $version];
         }
 
@@ -437,7 +437,7 @@ class DocumentService {
                 throw new \Exception($this->trans->t("Not supported version"));
             }
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "commandRequest on check error", "app" => self::$appName]);
+            $logger->error("commandRequest on check error", ['exception' => $e]);
             return [$e->getMessage(), $version];
         }
 
@@ -455,14 +455,14 @@ class DocumentService {
                 $logger->debug("getConvertedUri skipped", ["app" => self::$appName]);
             }
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "getConvertedUri on check error", "app" => self::$appName]);
+            $logger->error("getConvertedUri on check error", ['exception' => $e]);
             return [$e->getMessage(), $version];
         }
 
         try {
             $this->request($convertedFileUri);
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "Request converted file on check error", "app" => self::$appName]);
+            $logger->error("Request converted file on check error", ['exception' => $e]);
             return [$e->getMessage(), $version];
         }
 

--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -402,7 +402,7 @@ class DocumentService {
      * @return array
      */
     public function checkDocServiceUrl($urlGenerator, $crypt) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
         $version = null;
 
         try {

--- a/lib/EmailManager.php
+++ b/lib/EmailManager.php
@@ -247,7 +247,7 @@ class EmailManager {
                 return false;
             }
         } catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Send email", "app" => $this->appName]);
+            $this->logger->error("Send email", ['exception' => $e]);
             return false;
         }
 

--- a/lib/FileVersions.php
+++ b/lib/FileVersions.php
@@ -258,8 +258,8 @@ class FileVersions {
         }
 
         $changesInfo = $view->getFileInfo($changesPath);
-        $rootView = \OC::$server->get(View::class);
-        $root = \OC::$server->get(IRootFolder::class);
+        $rootView = \OCP\Server::get(View::class);
+        $root = \OCP\Server::get(IRootFolder::class);
 
         $changes = new File($root, $rootView, $view->getAbsolutePath($changesPath), $changesInfo);
         \OCP\Log\logger('onlyoffice')->debug("getChangesFile: $fileId for $ownerId get changes $changesPath", ["app" => self::$appName]);

--- a/lib/FileVersions.php
+++ b/lib/FileVersions.php
@@ -204,7 +204,7 @@ class FileVersions {
 
             return $historyData;
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "getHistoryData: $fileId $versionId", "app" => self::$appName]);
+            $logger->error("getHistoryData: $fileId $versionId", ['exception' => $e]);
             return null;
         }
     }
@@ -313,7 +313,7 @@ class FileVersions {
 
             $logger->debug("saveHistory: $fileId for $ownerId stored changes $changesPath history $historyPath", ["app" => self::$appName]);
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "saveHistory: save $fileId history error", "app" => self::$appName]);
+            $logger->error("saveHistory: save $fileId history error", ['exception' => $e]);
         }
     }
 
@@ -448,7 +448,7 @@ class FileVersions {
 
             $logger->debug("saveAuthor: $fileId for $ownerId stored author $authorPath", ["app" => self::$appName]);
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "saveAuthor: save $fileId author error", "app" => self::$appName]);
+            $logger->error("saveAuthor: save $fileId author error", ['exception' => $e]);
         }
     }
 

--- a/lib/FileVersions.php
+++ b/lib/FileVersions.php
@@ -166,7 +166,7 @@ class FileVersions {
      * @return array
      */
     public static function getHistoryData($ownerId, $fileInfo, $versionId, $prevVersion) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         if ($ownerId === null || $fileInfo === null) {
             return null;
@@ -262,7 +262,7 @@ class FileVersions {
         $root = \OC::$server->get(IRootFolder::class);
 
         $changes = new File($root, $rootView, $view->getAbsolutePath($changesPath), $changesInfo);
-        \OC::$server->getLogger()->debug("getChangesFile: $fileId for $ownerId get changes $changesPath", ["app" => self::$appName]);
+        \OCP\Log\logger('onlyoffice')->debug("getChangesFile: $fileId for $ownerId get changes $changesPath", ["app" => self::$appName]);
 
         return $changes;
     }
@@ -276,7 +276,7 @@ class FileVersions {
      * @param string $prevVersion - previous version for check
      */
     public static function saveHistory($fileInfo, $history, $changes, $prevVersion) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         if ($fileInfo === null) {
             return;
@@ -324,7 +324,7 @@ class FileVersions {
      * @param FileInfo $fileInfo - file info
      */
     public static function deleteAllVersions($ownerId, $fileInfo = null) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
         $fileId = null;
         if ($fileInfo !== null) {
             $fileId = $fileInfo->getId();
@@ -359,7 +359,7 @@ class FileVersions {
             return;
         }
 
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
         $fileId = $fileInfo->getId();
         $logger->debug("deleteVersion $fileId ($versionId)", ["app" => self::$appName]);
 
@@ -385,7 +385,7 @@ class FileVersions {
      * Clear all version history
      */
     public static function clearHistory() {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         $userDatabase = new Database();
         $userIds = $userDatabase->getUsers();
@@ -415,7 +415,7 @@ class FileVersions {
      * @param IUser $author - version author
      */
     public static function saveAuthor($fileInfo, $author) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         if ($fileInfo === null || $author === null) {
             return;
@@ -480,7 +480,7 @@ class FileVersions {
         $authorDataString = $view->file_get_contents($authorPath);
         $author = json_decode($authorDataString, true);
 
-        \OC::$server->getLogger()->debug("getAuthor: $fileId v.$versionId for $ownerId get author $authorPath", ["app" => self::$appName]);
+        \OCP\Log\logger('onlyoffice')->debug("getAuthor: $fileId v.$versionId for $ownerId get author $authorPath", ["app" => self::$appName]);
 
         return $author;
     }
@@ -493,7 +493,7 @@ class FileVersions {
      * @param string $versionId - file version
      */
     public static function deleteAuthor($ownerId, $fileInfo, $versionId) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         $fileId = $fileInfo->getId();
 

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -97,7 +97,7 @@ class Hooks {
 
         KeyManager::delete($fileId);
 
-        \OC::$server->getLogger()->debug("Hook fileUpdate " . json_encode($params), ["app" => self::$appName]);
+        \OCP\Log\logger('onlyoffice')->debug("Hook fileUpdate " . json_encode($params), ["app" => self::$appName]);
     }
 
     /**
@@ -129,7 +129,7 @@ class Hooks {
 
             FileVersions::deleteAllVersions($ownerId, $fileInfo);
         } catch (\Exception $e) {
-            \OC::$server->getLogger()->logException($e, ["message" => "Hook: fileDelete " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: fileDelete " . json_encode($params), "app" => self::$appName]);
         }
     }
 
@@ -165,7 +165,7 @@ class Hooks {
             FileVersions::deleteVersion($ownerId, $fileInfo, $versionId);
             FileVersions::deleteAuthor($ownerId, $fileInfo, $versionId);
         } catch (\Exception $e) {
-            \OC::$server->getLogger()->logException($e, ["message" => "Hook: fileVersionDelete " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: fileVersionDelete " . json_encode($params), "app" => self::$appName]);
         }
     }
 
@@ -200,7 +200,7 @@ class Hooks {
 
             FileVersions::deleteVersion($ownerId, $fileInfo, $versionId);
         } catch (\Exception $e) {
-            \OC::$server->getLogger()->logException($e, ["message" => "Hook: fileVersionRestore " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: fileVersionRestore " . json_encode($params), "app" => self::$appName]);
         }
     }
 
@@ -223,7 +223,7 @@ class Hooks {
 
             ExtraPermissions::deleteList($shareIds);
         } catch (\Exception $e) {
-            \OC::$server->getLogger()->logException($e, ["message" => "Hook: extraPermissionsDelete " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: extraPermissionsDelete " . json_encode($params), "app" => self::$appName]);
         }
     }
 }

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -129,7 +129,7 @@ class Hooks {
 
             FileVersions::deleteAllVersions($ownerId, $fileInfo);
         } catch (\Exception $e) {
-            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: fileDelete " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->error("Hook: fileDelete " . json_encode($params), ['exception' => $e]);
         }
     }
 
@@ -165,7 +165,7 @@ class Hooks {
             FileVersions::deleteVersion($ownerId, $fileInfo, $versionId);
             FileVersions::deleteAuthor($ownerId, $fileInfo, $versionId);
         } catch (\Exception $e) {
-            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: fileVersionDelete " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->error("Hook: fileVersionDelete " . json_encode($params), ['exception' => $e]);
         }
     }
 
@@ -200,7 +200,7 @@ class Hooks {
 
             FileVersions::deleteVersion($ownerId, $fileInfo, $versionId);
         } catch (\Exception $e) {
-            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: fileVersionRestore " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->error("Hook: fileVersionRestore " . json_encode($params), ['exception' => $e]);
         }
     }
 
@@ -223,7 +223,7 @@ class Hooks {
 
             ExtraPermissions::deleteList($shareIds);
         } catch (\Exception $e) {
-            \OCP\Log\logger('onlyoffice')->logException($e, ["message" => "Hook: extraPermissionsDelete " . json_encode($params), "app" => self::$appName]);
+            \OCP\Log\logger('onlyoffice')->error("Hook: extraPermissionsDelete " . json_encode($params), ['exception' => $e]);
         }
     }
 }

--- a/lib/RemoteInstance.php
+++ b/lib/RemoteInstance.php
@@ -124,7 +124,7 @@ class RemoteInstance {
      * @return bool
      */
     public static function healthCheck($remote) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
         $remote = rtrim($remote, "/") . "/";
 
         if (array_key_exists($remote, self::$healthRemote)) {
@@ -177,7 +177,7 @@ class RemoteInstance {
      * @return string
      */
     public static function getRemoteKey($file) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         $remote = rtrim($file->getStorage()->getRemote(), "/") . "/";
         $shareToken = $file->getStorage()->getToken();
@@ -229,7 +229,7 @@ class RemoteInstance {
      * @return bool
      */
     public static function lockRemoteKey($file, $lock, $fs) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
         $action = $lock ? "lock" : "unlock";
 
         $remote = rtrim($file->getStorage()->getRemote(), "/") . "/";

--- a/lib/RemoteInstance.php
+++ b/lib/RemoteInstance.php
@@ -153,7 +153,7 @@ class RemoteInstance {
                 $status = $data["alive"] === true;
             }
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "Failed to request federated health check for" . $remote, "app" => self::APP_NAME]);
+            $logger->error("Failed to request federated health check for" . $remote, ['exception' => $e]);
         }
 
         if (empty($dbremote)) {
@@ -208,7 +208,7 @@ class RemoteInstance {
 
             return $key;
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "Failed to request federated key " . $file->getId(), "app" => self::APP_NAME]);
+            $logger->error("Failed to request federated key " . $file->getId(), ['exception' => $e]);
 
             if ($e->getResponse()->getStatusCode() === 404) {
                 self::update($remote, false);
@@ -266,7 +266,7 @@ class RemoteInstance {
                 return false;
             }
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "Failed to request federated " . $action . " for " . $file->getFileInfo()->getId(), "app" => self::APP_NAME]);
+            $logger->error("Failed to request federated " . $action . " for " . $file->getFileInfo()->getId(), ['exception' => $e]);
             return false;
         }
     }

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -101,7 +101,7 @@ class TemplateManager {
      * @return File
      */
     public static function getTemplate($templateId) {
-        $logger = \OC::$server->getLogger();
+        $logger = \OCP\Log\logger('onlyoffice');
 
         if (empty($templateId)) {
             $logger->info("templateId is empty", ["app" => self::$appName]);

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -112,7 +112,7 @@ class TemplateManager {
         try {
             $templates = $templateDir->getById($templateId);
         } catch (\Exception $e) {
-            $logger->logException($e, ["message" => "getTemplate: $templateId", "app" => self::$appName]);
+            $logger->error("getTemplate: $templateId", ['exception' => $e]);
             return null;
         }
 

--- a/templates/editor.php
+++ b/templates/editor.php
@@ -51,7 +51,7 @@ if (!empty($_["directToken"])) {
         data-inviewer="<?php p($_["inviewer"]) ?>"></div>
 
     <?php if (!empty($_["documentServerUrl"])) { ?>
-        <script nonce="<?php p(\OC::$server->get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce()) ?>"
+        <script nonce="<?php p(\OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce()) ?>"
             src="<?php p($_["documentServerUrl"]) ?>web-apps/apps/api/documents/api.js" type="text/javascript"></script>
     <?php } ?>
 


### PR DESCRIPTION
Follow up to https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/1041  as there were quite some parts missing which makes the app not work properly with upcomping Nextcloud 31

- getLogger is removed since https://github.com/nextcloud/server/pull/47978/, replacing with the public logger method that does the same thing
- Move away from `\OC::$server` as it is internal API, ideally the app should use dependency injection more, but for quick migration switching to `\OCP\Server::get` works 
- Remove usage of logException which is no longer available, also no need to pass app to each log statement as when getting the logger in the app scope we already have that set
- Cleanup service registration in Application.php as these days services will be auto wired based on the class name
- Move AppConfig over to use constructor property promotion as a new feature of PHP 8.0 that allows less lines of code
