### PR TITLE
fix: editor don't show changes in file on group folder if it's restored from files_versions

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -175,7 +175,7 @@ class Hooks {
      * @param array $params - hook param
      */
     public static function fileVersionRestore($params) {
-        $filePath = $params["path"];
+        $filePath = preg_replace('/^\/\w+\/files\//', '', $params["node"]->getPath());
         if (empty($filePath)) {
             return;
         }


### PR DESCRIPTION
If file is in a [group folder](https://github.com/nextcloud/groupfolders) and is restored from files_versions, OnlyOffice don't delete cache of the previous version causing the editor to display an old version.

This remove cache even if the file is in group folder.

### Problem

If the file is in group folder, the full path to the group folder isn't in `$params["path"]`.

Example:

Group folder: `Hello`
File: `Hello/goodbye.xlsx`

```
$params["path"] = "goodbye.xlsx"
```

Because `goodbye.xlsx` doesn't match in the home of the user, the function returns without delete cache.

### Solution

Get the path from `$params["node"]->getPath()` and removes prefix "/admin/files".

```
$params["node"]->getPath() = "/admin/files/Hello/goodbye.xlsx"
preg_replace('/^\/\w+\/files\//', '', $params["node"]->getPath()) =  "Hello/goodbye.xlsx"
```

The new $filePath: "Hello/goodbye.txt"
