### PR TITLE
fix: Use proper method to get the user id from the session

### DIFF
--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -286,8 +286,8 @@ class CallbackController extends Controller {
         }
 
         if ((!empty($user) && !$file->isReadable()) || !$canDownload) {
-            if ($this->userSession->getUID() != $userId) {
-                $this->logger->error("Download error: expected $userId instead of " . $this->userSession->getUID());
+            if ($this->userSession->getUser()?->getUID() != $userId) {
+                $this->logger->error("Download error: expected $userId instead of " . $this->userSession->getUser()?->getUID());
             }
             $this->logger->error("Download without access right");
             return new JSONResponse(["message" => $this->trans->t("Access denied")], Http::STATUS_FORBIDDEN);


### PR DESCRIPTION
There is no method getUID on the user session, so this should fix cases where an error is thrown on downloading a file