### PR TITLE
fix: Properly handle authenticated links being an array

### DIFF
--- a/lib/FileUtility.php
+++ b/lib/FileUtility.php
@@ -208,9 +208,12 @@ class FileUtility {
             return [null, $this->trans->t("You do not have enough permissions to view the file")];
         }
 
-        if ($share->getPassword()
-            && (!$this->session->exists("public_link_authenticated")
-                || $this->session->get("public_link_authenticated") !== (string) $share->getId())) {
+        $authenticatedLinks = $this->session->get('public_link_authenticated');
+
+        $isAuthenticated = is_array($authenticatedLinks) && in_array($share->getId(), $authenticatedLinks);
+        $isAuthenticated = $isAuthenticated || $authenticatedLinks === (string) $share->getId();
+
+        if ($share->getPassword() && !$isAuthenticated) {
             return [null, $this->trans->t("You do not have enough permissions to view the file")];
         }
 


### PR DESCRIPTION
With the last patch release of Nextcloud the value of the public_link_authenticated session value changed from a single share id to an array of share ids. This caused share links with passwords to no longer work.

This patch fixes this and keeps a fallback for older server versions.