### PR TITLE
Guard openfile flag when ONLYOFFICE not default

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -217,10 +217,17 @@ import { loadState } from '@nextcloud/initial-state'
 			const scrollTop = $('#app-content').scrollTop()
 			$(OCA.Onlyoffice.frameSelector).css('top', scrollTop)
 
+			const currentQuery = { ...OCP.Files.Router.query }
+			if (isDefault) {
+				currentQuery.openfile = 'true'
+			} else {
+				delete currentQuery.openfile
+			}
+
 			window.OCP?.Files?.Router?.goToRoute(
 				null, // use default route
 				{ view: 'files', fileid: fileId },
-				{ ...OCP.Files.Router.query, openfile: 'true' },
+				currentQuery,
 			)
 		}
 	}
@@ -242,7 +249,7 @@ import { loadState } from '@nextcloud/initial-state'
 		window.OCP?.Files?.Router?.goToRoute(
 			null, // use default route
 			{ view: 'files', fileid: undefined },
-			{ ...OCP.Files.Router.query, openfile: 'false', enableSharing: undefined },
+			{ ...OCP.Files.Router.query, openfile: undefined, enableSharing: undefined },
 		)
 	}
 


### PR DESCRIPTION
## Summary
- only set Files router openfile flag when ONLYOFFICE is the default handler
- clear the flag instead of forcing false when closing the inline editor

## Context
When same-tab editing is enabled the connector always set openfile=true, even if Nextcloud Text was the default for text/plain. Files opened Text first and ONLYOFFICE only appeared after closing Text.

## Testing
- Manual: open a .txt with ONLYOFFICE configured same-tab while Text is the default editor, verify ONLYOFFICE opens without Text overlaying first
- Manual: open a .docx same-tab, close editor, routing resets as before