### PR TITLE
fix: Issue with property name mismatch

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -623,7 +623,7 @@ import { loadState } from '@nextcloud/initial-state'
 
 						const attributes = JSON.parse(files[0].attributes['share-attributes'])
 						const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
-						if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
+						if (downloadAttribute !== undefined && downloadAttribute.value === false) { return false }
 					}
 
 					return true
@@ -649,7 +649,7 @@ import { loadState } from '@nextcloud/initial-state'
 
 						const attributes = JSON.parse(files[0].attributes['share-attributes'])
 						const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
-						if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
+						if (downloadAttribute !== undefined && downloadAttribute.value === false) { return false }
 					}
 
 					return true
@@ -676,7 +676,7 @@ import { loadState } from '@nextcloud/initial-state'
 						if (files[0].attributes['mount-type'] === 'shared') {
 							const attributes = JSON.parse(files[0].attributes['share-attributes'])
 							const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
-							if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
+							if (downloadAttribute !== undefined && downloadAttribute.value === false) { return false }
 						}
 
 						return true


### PR DESCRIPTION
OO download-as share-attributes: `[{"scope":"permissions","key":"download","value":false}]` shared

but your code is looking for: `downloadAttribute.enabled` - it should be `value`