### PR TITLE
fix: TypeError on request user info for a null user

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -427,6 +427,9 @@ class EditorController extends Controller {
 
         if ($userIds !== null && is_array($userIds)) {
             foreach ($userIds as $userId) {
+                if (!is_string($userId)) {
+                    continue;
+                }
                 $userData = [];
                 $user = $this->userManager->get($this->getUserId($userId));
                 if (!empty($user)) {

--- a/tests/integration/behat/features/bootstrap/CoreContext.php
+++ b/tests/integration/behat/features/bootstrap/CoreContext.php
@@ -402,6 +402,12 @@ class CoreContext implements Context
         $this->requestUserInfo([$userId]);
     }
 
+    #[When('I request user info for a null user')]
+    public function iRequestUserInfoForANullUser(): void
+    {
+        $this->requestUserInfo([null]);
+    }
+
     #[Then('the response should contain one user')]
     public function theResponseShouldContainOneUser(): void
     {

--- a/tests/integration/behat/features/core/editor/user_info.feature
+++ b/tests/integration/behat/features/core/editor/user_info.feature
@@ -19,6 +19,11 @@ Feature: Editor get user info
     When I request user info for "nonexistentuser"
     Then the response should be an empty list
 
+  Scenario: A null user id is silently omitted without error
+    When I request user info for a null user
+    Then the response status code should be 200
+    And the response should be an empty list
+
   Scenario: A user without a custom avatar has no image field
     Given a user with display name "Alice Tester" and an email exists
     When I request user info for that user


### PR DESCRIPTION
This kills the TypeError and also hardens against numbers, booleans, or nested arrays in the decoded payload.

Fixing it here (rather than loosening `getUserId` to `?string`) is correct because the null originates in the Document Server. The endpoint must be robust regardless of what it's sent, and a null author simply has no info to return.

> OCA\\Onlyoffice\\Controller\\EditorController::getUserId(): Argument #1 ($userId) must be of type string, null given