### PR TITLE
fix: garbage collect stale version history storage

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -51,5 +51,6 @@ Whether you’re working with internal teams or external collaborators, the ONLY
     </commands>
     <background-jobs>
         <job>OCA\Onlyoffice\Cron\EditorsCheck</job>
+        <job>OCA\Onlyoffice\Cron\HistoryCleanup</job>
     </background-jobs>
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,6 +49,8 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\Files_Versions\Events\VersionRestoredEvent;
+use OCA\GroupFolders\Event\GroupVersionsExpireDeleteFileEvent;
+use OCA\GroupFolders\Event\GroupVersionsExpireDeleteVersionEvent;
 use OCA\Viewer\Event\LoadViewer;
 use OCA\Onlyoffice\AppConfig;
 use OCA\Onlyoffice\Controller\JobListController;
@@ -64,6 +66,7 @@ use OCA\Onlyoffice\Listeners\ContentSecurityPolicyListener;
 use OCA\Onlyoffice\Listeners\DocumentUnsavedListener;
 use OCA\Onlyoffice\Listeners\FileListener;
 use OCA\Onlyoffice\Listeners\FileVersionsListener;
+use OCA\Onlyoffice\Listeners\GroupFolderVersionsListener;
 use OCA\Onlyoffice\Listeners\MailMergeEndedListener;
 use OCA\Onlyoffice\Listeners\ShareListener;
 use OCA\Onlyoffice\Listeners\UserListener;
@@ -108,6 +111,8 @@ class Application extends App implements IBootstrap {
         $context->registerEventListener(ShareDeletedEvent::class, ShareListener::class);
         $context->registerEventListener(UserDeletedEvent::class, UserListener::class);
         $context->registerEventListener(VersionRestoredEvent::class, FileVersionsListener::class);
+        $context->registerEventListener(GroupVersionsExpireDeleteVersionEvent::class, GroupFolderVersionsListener::class);
+        $context->registerEventListener(GroupVersionsExpireDeleteFileEvent::class, GroupFolderVersionsListener::class);
         $context->registerEventListener(MailMergeEndedEvent::class, MailMergeEndedListener::class);
 
         if (interface_exists(\OCP\Files\Template\ICustomTemplateProvider::class)) {

--- a/lib/Controller/JobListController.php
+++ b/lib/Controller/JobListController.php
@@ -38,6 +38,7 @@ namespace OCA\Onlyoffice\Controller;
 
 use OCA\Onlyoffice\AppConfig;
 use OCA\Onlyoffice\Cron\EditorsCheck;
+use OCA\Onlyoffice\Cron\HistoryCleanup;
 use OCP\AppFramework\Controller;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
@@ -100,10 +101,19 @@ class JobListController extends Controller {
     }
 
     /**
+     * Add HistoryCleanup job to the list
+     *
+     */
+    private function checkHistoryCleanupJob(): void {
+        $this->addJob(HistoryCleanup::class);
+    }
+
+    /**
      * Method for sequentially calling checks of all jobs
      *
      */
     public function checkAllJobs(): void {
         $this->checkEditorsCheckJob();
+        $this->checkHistoryCleanupJob();
     }
 }

--- a/lib/Cron/HistoryCleanup.php
+++ b/lib/Cron/HistoryCleanup.php
@@ -1,0 +1,282 @@
+<?php
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Onlyoffice\Cron;
+
+use OC\Files\View;
+use OCA\Files_Versions\Versions\IVersionManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+use OCP\Files\File;
+use OCP\Files\FileInfo;
+use OCP\Files\IRootFolder;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Garbage collection background job for the version history storage
+ *
+ * The stored changes, history and author files are normally removed in
+ * reaction to events (file deletion, version expiration), but several
+ * deletion paths never emit those events: deleting a folder does not
+ * dispatch per-file NodeDeletedEvent, version expiration cannot always
+ * resolve the file and removing a whole group folder is silent. This job
+ * reconciles the history storage with the existing files and versions.
+ *
+ * A history folder is only removed once the source file it belongs to no
+ * longer has any entry in the file cache, which is layout independent and
+ * true only when the file has been permanently deleted: a file that still
+ * exists - even on a currently unavailable external mount or after an
+ * ownership transfer - keeps its file cache row, so its history is never
+ * removed by mistake.
+ */
+class HistoryCleanup extends TimedJob {
+
+    /**
+     * Groupfolder name
+     */
+    private static string $groupFolderName = "__groupfolders";
+
+    /**
+     * Pattern of the stored version file names (changes, history and author)
+     */
+    private static string $versionFilePattern = "/^(\d+)(\.zip|\.json|_author\.json)$/";
+
+    /**
+     * Count of removed history folders
+     */
+    private int $deletedFolders = 0;
+
+    /**
+     * Count of removed version files
+     */
+    private int $deletedFiles = 0;
+
+    public function __construct(
+        ITimeFactory $time,
+        private readonly string $appName,
+        private readonly IUserManager $userManager,
+        private readonly IRootFolder $rootFolder,
+        private readonly IDBConnection $connection,
+        private readonly LoggerInterface $logger,
+        private readonly ?IVersionManager $versionManager
+    ) {
+        parent::__construct($time);
+        $this->setInterval(60 * 60 * 24 * 7);
+        $this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+    }
+
+    /**
+     * Makes the history garbage collection
+     *
+     * @param array $argument unused argument
+     */
+    protected function run($argument): void {
+        $this->deletedFolders = 0;
+        $this->deletedFiles = 0;
+
+        $this->userManager->callForSeenUsers(function (IUser $user): void {
+            try {
+                $this->cleanupUserHistory($user);
+            } catch (Throwable $e) {
+                $this->logger->error("HistoryCleanup: cleanup for user {$user->getUID()} error", ["exception" => $e]);
+            } finally {
+                \OC_Util::tearDownFS();
+            }
+        });
+
+        try {
+            $this->cleanupGroupFolderHistory();
+        } catch (Throwable $e) {
+            $this->logger->error("HistoryCleanup: cleanup for group folders error", ["exception" => $e]);
+        }
+
+        $this->logger->info("HistoryCleanup: removed {$this->deletedFolders} orphaned history folders and {$this->deletedFiles} stale version files", ["app" => $this->appName]);
+    }
+
+    /**
+     * Remove history of deleted files and expired versions of a user
+     *
+     * @param IUser $user - user
+     */
+    private function cleanupUserHistory(IUser $user): void {
+        $userId = $user->getUID();
+
+        $view = new View("/" . $userId);
+        if (!$view->is_dir($this->appName)) {
+            return;
+        }
+
+        $userFolder = $this->rootFolder->getUserFolder($userId);
+
+        $entries = $view->getDirectoryContent($this->appName);
+        if (!is_array($entries)) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            $name = $entry->getName();
+            if ($entry->getType() !== FileInfo::TYPE_FOLDER || !ctype_digit($name)) {
+                continue;
+            }
+
+            $fileId = (int)$name;
+            $path = $this->appName . "/" . $name;
+
+            // The source file was permanently deleted: reclaim the whole folder.
+            if (!$this->fileExistsInCache($fileId)) {
+                $view->unlink($path);
+                $this->deletedFolders++;
+                continue;
+            }
+
+            // The source file still exists: drop the stored changes of versions
+            // that files_versions has already expired. Skip (never delete) when
+            // it cannot be resolved here, e.g. on a currently offline mount.
+            if ($this->versionManager === null) {
+                continue;
+            }
+
+            $file = $userFolder->getFirstNodeById($fileId);
+            if (!($file instanceof File)) {
+                continue;
+            }
+
+            $keepIds = [];
+            try {
+                foreach ($this->versionManager->getVersionsForFile($user, $file) as $version) {
+                    $keepIds[(string)$version->getRevisionId()] = true;
+                }
+            } catch (Throwable $e) {
+                $this->logger->debug("HistoryCleanup: cannot get versions of $name", ["exception" => $e]);
+                continue;
+            }
+
+            $this->cleanupVersionFiles($view, $path, $keepIds, $file->getMTime());
+        }
+    }
+
+    /**
+     * Remove history of deleted files in group folders
+     *
+     * Per-version cleanup of still-existing group folder files is handled by
+     * GroupFolderVersionsListener, since the group folder version layout is
+     * internal to the groupfolders app and must not be assumed here. As a
+     * consequence there is no periodic backstop for a group folder file whose
+     * expiry event was missed (app disabled at the time, listener error): its
+     * stale per-version files are only reclaimed once the whole file is
+     * deleted. This is an accepted trade-off against guessing at the internal
+     * layout, which previously deleted history of live files by mistake.
+     */
+    private function cleanupGroupFolderHistory(): void {
+        $view = new View("/" . self::$groupFolderName);
+        if (!$view->is_dir($this->appName)) {
+            return;
+        }
+
+        $entries = $view->getDirectoryContent($this->appName);
+        if (!is_array($entries)) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            $name = $entry->getName();
+            if ($entry->getType() !== FileInfo::TYPE_FOLDER || !ctype_digit($name)) {
+                continue;
+            }
+
+            if (!$this->fileExistsInCache((int)$name)) {
+                $view->unlink($this->appName . "/" . $name);
+                $this->deletedFolders++;
+            }
+        }
+    }
+
+    /**
+     * Remove stored version files that do not belong to an existing version
+     *
+     * @param View $view - view of the history storage
+     * @param string $path - path of the file history folder
+     * @param array $keepIds - version ids that still exist
+     * @param int $mtime - current file modification time
+     */
+    private function cleanupVersionFiles(View $view, string $path, array $keepIds, int $mtime): void {
+        $entries = $view->getDirectoryContent($path);
+        if (!is_array($entries)) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if (!preg_match(self::$versionFilePattern, $entry->getName(), $matches)) {
+                continue;
+            }
+
+            $versionId = $matches[1];
+            if (isset($keepIds[$versionId]) || (int)$versionId >= $mtime) {
+                continue;
+            }
+
+            $view->unlink($path . "/" . $entry->getName());
+            $this->deletedFiles++;
+        }
+    }
+
+    /**
+     * Check whether a file id still has an entry in the file cache
+     *
+     * A file that exists anywhere - any storage, any group folder, or the
+     * trash - keeps its file cache row, so this returns false only when the
+     * file has been permanently deleted.
+     *
+     * @param int $fileId - file id
+     */
+    private function fileExistsInCache(int $fileId): bool {
+        $select = $this->connection->prepare("
+            SELECT `fileid`
+            FROM `*PREFIX*filecache`
+            WHERE `fileid` = ?
+        ");
+        $result = $select->execute([$fileId]);
+        $exists = $result->fetchOne();
+        $result->closeCursor();
+
+        return $exists !== false;
+    }
+}

--- a/lib/FileVersions.php
+++ b/lib/FileVersions.php
@@ -38,12 +38,12 @@ namespace OCA\Onlyoffice;
 
 use OC\Files\Node\File;
 use OC\Files\View;
-use OC\User\Database;
 use OCA\Files_Sharing\External\Storage as SharingExternalStorage;
 use OCA\GroupFolders\Mount\GroupFolderStorage;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IUser;
+use OCP\IUserManager;
 
 /**
  * File versions
@@ -367,27 +367,41 @@ class FileVersions {
     }
 
     /**
+     * Delete all versions of a group folder file that no longer exists
+     *
+     * @param int $fileId - file id
+     */
+    public static function deleteGroupFolderVersions(int $fileId): void {
+        \OCP\Log\logger('onlyoffice')->debug("deleteGroupFolderVersions $fileId", ["app" => self::$appName]);
+
+        $view = new View("/" . self::$groupFolderName);
+
+        $path = self::$appName . "/" . $fileId;
+        if ($view->file_exists($path)) {
+            $view->unlink($path);
+        }
+    }
+
+    /**
      * Clear all version history
      */
     public static function clearHistory(): void {
         $logger = \OCP\Log\logger('onlyoffice');
 
-        $userDatabase = new Database();
-        $userIds = $userDatabase->getUsers();
+        $userManager = \OCP\Server::get(IUserManager::class);
 
         $view = new View("/");
-        $groupFolderView = new View("/" . self::$groupFolderName);
-
-        foreach ($userIds as $userId) {
-            $path = $userId . "/" . self::$appName;
+        $userManager->callForSeenUsers(function (IUser $user) use ($view): void {
+            $path = $user->getUID() . "/" . self::$appName;
 
             if ($view->file_exists($path)) {
                 $view->unlink($path);
             }
+        });
 
-            if ($groupFolderView->file_exists($path)) {
-                $groupFolderView->unlink($path);
-            }
+        $groupFolderView = new View("/" . self::$groupFolderName);
+        if ($groupFolderView->file_exists(self::$appName)) {
+            $groupFolderView->unlink(self::$appName);
         }
 
         $logger->debug("clear all history", ["app" => self::$appName]);

--- a/lib/Listeners/GroupFolderVersionsListener.php
+++ b/lib/Listeners/GroupFolderVersionsListener.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Onlyoffice\Listeners;
+
+use OCA\GroupFolders\Event\GroupVersionsExpireDeleteFileEvent;
+use OCA\GroupFolders\Event\GroupVersionsExpireDeleteVersionEvent;
+use OCA\Onlyoffice\FileVersions;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * OCA\GroupFolders events listener
+ *
+ * Group folder version expiration bypasses the \OCP\Versions hooks emitted
+ * by files_versions, so the stored changes and history have to be removed
+ * in reaction to the events of the groupfolders app.
+ */
+class GroupFolderVersionsListener implements IEventListener {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function handle(Event $event): void {
+        if ($event instanceof GroupVersionsExpireDeleteVersionEvent) {
+            $this->versionDeleted($event);
+        }
+
+        if ($event instanceof GroupVersionsExpireDeleteFileEvent) {
+            $this->fileDeleted($event);
+        }
+    }
+
+    private function versionDeleted(GroupVersionsExpireDeleteVersionEvent $event): void {
+        try {
+            $version = $event->version;
+            $file = $version->getSourceFile();
+
+            $owner = $file->getOwner();
+            $ownerId = $owner !== null ? $owner->getUID() : $version->getUser()->getUID();
+
+            $versionId = (string)$version->getRevisionId();
+
+            FileVersions::deleteVersion($ownerId, $file, $versionId);
+            FileVersions::deleteAuthor($ownerId, $file, $versionId);
+        } catch (Throwable $e) {
+            $this->logger->error(
+                "GroupVersionsExpireDeleteVersionEvent: deleting expired version",
+                ["exception" => $e]
+            );
+        }
+    }
+
+    private function fileDeleted(GroupVersionsExpireDeleteFileEvent $event): void {
+        try {
+            FileVersions::deleteGroupFolderVersions((int)$event->fileId);
+        } catch (Throwable $e) {
+            $this->logger->error(
+                "GroupVersionsExpireDeleteFileEvent: deleting versions for file {$event->fileId}",
+                ["exception" => $e]
+            );
+        }
+    }
+}

--- a/tests/integration/lib/FileVersionsTest.php
+++ b/tests/integration/lib/FileVersionsTest.php
@@ -40,6 +40,7 @@ declare(strict_types=1);
 namespace OCA\Onlyoffice\Tests\Integration;
 
 use OC\Files\Node\File;
+use OC\Files\View;
 use OCA\Onlyoffice\FileVersions;
 use OCP\Files\IRootFolder;
 use OCP\IUser;
@@ -78,9 +79,28 @@ class FileVersionsTest extends TestCase {
             $this->file->delete();
         }
 
+        $groupFolderView = new View("/__groupfolders");
+        if ($groupFolderView->file_exists("onlyoffice")) {
+            $groupFolderView->unlink("onlyoffice");
+        }
+
         self::logout();
         $this->tearDownUserTrait();
         parent::tearDown();
+    }
+
+    private function getGroupFolderView(): View {
+        $rootView = new View("/");
+        if (!$rootView->is_dir("__groupfolders")) {
+            $rootView->mkdir("__groupfolders");
+        }
+
+        $view = new View("/__groupfolders");
+        if (!$view->is_dir("onlyoffice")) {
+            $view->mkdir("onlyoffice");
+        }
+
+        return $view;
     }
 
     /**
@@ -257,5 +277,35 @@ class FileVersionsTest extends TestCase {
         FileVersions::saveAuthor($this->file, null);
 
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * deleteGroupFolderVersions removes the stored history folder of a group folder file.
+     */
+    public function testDeleteGroupFolderVersionsRemovesHistoryFolder(): void {
+        $view = $this->getGroupFolderView();
+        $view->mkdir("onlyoffice/999999901");
+        $view->file_put_contents("onlyoffice/999999901/1000.zip", "changes-data");
+
+        FileVersions::deleteGroupFolderVersions(999999901);
+
+        $this->assertFalse($view->file_exists("onlyoffice/999999901"));
+    }
+
+    /**
+     * clearHistory removes the stored history of seen users and of group folders.
+     */
+    public function testClearHistoryRemovesUserAndGroupFolderHistory(): void {
+        FileVersions::saveHistory($this->file, ["key" => "v1"], "changes-data", "prev");
+        $this->assertTrue(FileVersions::hasChanges($this->userId, $this->file, $this->versionId));
+
+        $view = $this->getGroupFolderView();
+        $view->mkdir("onlyoffice/999999902");
+        $view->file_put_contents("onlyoffice/999999902/1000.zip", "changes-data");
+
+        FileVersions::clearHistory();
+
+        $this->assertFalse(FileVersions::hasChanges($this->userId, $this->file, $this->versionId));
+        $this->assertFalse($view->file_exists("onlyoffice"));
     }
 }

--- a/tests/integration/lib/HistoryCleanupTest.php
+++ b/tests/integration/lib/HistoryCleanupTest.php
@@ -1,0 +1,252 @@
+<?php
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Onlyoffice\Tests\Integration;
+
+use OC\Files\View;
+use OCA\Files_Versions\Versions\IVersionManager;
+use OCA\Onlyoffice\Cron\HistoryCleanup;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use OCP\Server;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+#[CoversClass(HistoryCleanup::class)]
+#[Group('DB')]
+class HistoryCleanupTest extends TestCase {
+    use UserTrait;
+
+    private string $userId = "onlyoffice-hc-testuser";
+    private IUser $user;
+    private ?IUser $otherUser = null;
+    private File $file;
+    private View $userView;
+    private View $groupFolderView;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->setUpUserTrait();
+
+        $this->user = $this->createUser($this->userId, "password");
+        self::loginAsUser($this->userId);
+
+        $userFolder = Server::get(IRootFolder::class)->getUserFolder($this->userId);
+        $this->file = $userFolder->newFile("test-historycleanup.docx", "initial content");
+
+        $this->userView = new View("/" . $this->userId);
+        $this->userView->mkdir("onlyoffice");
+
+        $rootView = new View("/");
+        if (!$rootView->is_dir("__groupfolders")) {
+            $rootView->mkdir("__groupfolders");
+        }
+        $this->groupFolderView = new View("/__groupfolders");
+        $this->groupFolderView->mkdir("onlyoffice");
+    }
+
+    protected function tearDown(): void {
+        if ($this->userView->is_dir("onlyoffice")) {
+            $this->userView->unlink("onlyoffice");
+        }
+
+        foreach (["onlyoffice", "1"] as $path) {
+            if ($this->groupFolderView->file_exists($path)) {
+                $this->groupFolderView->unlink($path);
+            }
+        }
+
+        if ($this->file->isReadable()) {
+            $this->file->delete();
+        }
+
+        if ($this->otherUser !== null) {
+            $this->otherUser->delete();
+            $this->otherUser = null;
+        }
+
+        self::logout();
+        $this->tearDownUserTrait();
+        parent::tearDown();
+    }
+
+    private function runJob(): void {
+        $job = Server::get(HistoryCleanup::class);
+        self::invokePrivate($job, "run", [[]]);
+        self::loginAsUser($this->userId);
+    }
+
+    /**
+     * The history folder of a file that no longer exists is removed,
+     * the history folder of an existing file is kept.
+     */
+    public function testRunRemovesOrphanedUserHistoryFolder(): void {
+        $this->userView->mkdir("onlyoffice/999999990");
+        $this->userView->file_put_contents("onlyoffice/999999990/1000.zip", "changes");
+
+        $fileId = $this->file->getId();
+        $mtime = $this->file->getMTime();
+        $this->userView->mkdir("onlyoffice/" . $fileId);
+        $this->userView->file_put_contents("onlyoffice/" . $fileId . "/" . $mtime . ".zip", "changes");
+
+        $this->runJob();
+
+        $this->assertFalse($this->userView->file_exists("onlyoffice/999999990"));
+        $this->assertTrue($this->userView->file_exists("onlyoffice/" . $fileId . "/" . $mtime . ".zip"));
+    }
+
+    /**
+     * A history folder whose source file still exists but cannot be resolved
+     * in this owner's tree - as happens on a currently offline external mount
+     * or after an ownership transfer - is kept, because the file still has a
+     * file cache row. This is the core safety property of the orphan check:
+     * only a permanently deleted file loses its cache row.
+     */
+    public function testRunKeepsHistoryOfExistingButUnresolvableFile(): void {
+        $otherUserId = $this->userId . "-other";
+        $this->otherUser = $this->createUser($otherUserId, "password");
+
+        self::loginAsUser($otherUserId);
+        $otherFolder = Server::get(IRootFolder::class)->getUserFolder($otherUserId);
+        $otherFile = $otherFolder->newFile("other-historycleanup.docx", "content");
+        $otherFileId = $otherFile->getId();
+        self::loginAsUser($this->userId);
+
+        // history folder under THIS user, named with the other user's file id:
+        // the file exists (cache row present) but getFirstNodeById returns null
+        // for this user, so version reconciliation is skipped and nothing is removed.
+        $this->userView->mkdir("onlyoffice/" . $otherFileId);
+        $this->userView->file_put_contents("onlyoffice/" . $otherFileId . "/1000.zip", "changes");
+
+        $this->runJob();
+
+        $this->assertTrue($this->userView->file_exists("onlyoffice/" . $otherFileId . "/1000.zip"));
+    }
+
+    /**
+     * Version files that match neither an existing version nor the current
+     * file state are removed, the file of the current state is kept.
+     */
+    public function testRunRemovesStaleVersionFilesOfExistingFile(): void {
+        $fileId = $this->file->getId();
+        $mtime = $this->file->getMTime();
+        $path = "onlyoffice/" . $fileId;
+
+        $this->userView->mkdir($path);
+        $this->userView->file_put_contents($path . "/" . $mtime . ".zip", "changes");
+        $this->userView->file_put_contents($path . "/" . $mtime . ".json", "{}");
+        $this->userView->file_put_contents($path . "/1000.zip", "changes");
+        $this->userView->file_put_contents($path . "/1000.json", "{}");
+        $this->userView->file_put_contents($path . "/1000_author.json", "{}");
+        $this->userView->file_put_contents($path . "/unrelated.txt", "keep me");
+
+        $this->runJob();
+
+        $this->assertTrue($this->userView->file_exists($path . "/" . $mtime . ".zip"));
+        $this->assertTrue($this->userView->file_exists($path . "/" . $mtime . ".json"));
+        $this->assertFalse($this->userView->file_exists($path . "/1000.zip"));
+        $this->assertFalse($this->userView->file_exists($path . "/1000.json"));
+        $this->assertFalse($this->userView->file_exists($path . "/1000_author.json"));
+        $this->assertTrue($this->userView->file_exists($path . "/unrelated.txt"));
+    }
+
+    /**
+     * Version files of versions that still exist in files_versions are kept.
+     */
+    public function testRunKeepsVersionFilesOfExistingVersions(): void {
+        $oldMtime = time() - 3600;
+        $this->file->touch($oldMtime);
+        $this->file->putContent("updated content");
+
+        $userFolder = Server::get(IRootFolder::class)->getUserFolder($this->userId);
+        $this->file = $userFolder->get("test-historycleanup.docx");
+
+        $versionManager = Server::get(IVersionManager::class);
+        $revisionIds = [];
+        foreach ($versionManager->getVersionsForFile($this->user, $this->file) as $version) {
+            $revisionIds[] = (string)$version->getRevisionId();
+        }
+        if (!in_array((string)$oldMtime, $revisionIds, true)) {
+            $this->markTestSkipped("files_versions did not store a version for the old mtime");
+        }
+
+        $fileId = $this->file->getId();
+        $path = "onlyoffice/" . $fileId;
+        $this->userView->mkdir($path);
+        $this->userView->file_put_contents($path . "/" . $oldMtime . ".zip", "changes");
+        $this->userView->file_put_contents($path . "/1000.zip", "changes");
+
+        $this->runJob();
+
+        $this->assertTrue($this->userView->file_exists($path . "/" . $oldMtime . ".zip"));
+        $this->assertFalse($this->userView->file_exists($path . "/1000.zip"));
+    }
+
+    /**
+     * The group folder history of a permanently deleted file is removed,
+     * while the history of a file that still exists is kept wholesale.
+     *
+     * Per-version pruning of existing group folder files is intentionally not
+     * done by the job (GroupFolderVersionsListener handles it), so every
+     * stored file of a still-existing source file is retained.
+     */
+    public function testRunCleansGroupFolderHistory(): void {
+        // orphaned history folder: no file with this id exists
+        $this->groupFolderView->mkdir("onlyoffice/999999991");
+        $this->groupFolderView->file_put_contents("onlyoffice/999999991/1000.zip", "changes");
+
+        // existing file inside a group folder
+        $this->groupFolderView->mkdir("1");
+        $this->groupFolderView->file_put_contents("1/test-historycleanup.docx", "content");
+        $fileInfo = $this->groupFolderView->getFileInfo("1/test-historycleanup.docx");
+        $fileId = $fileInfo->getId();
+        $mtime = $fileInfo->getMtime();
+
+        $path = "onlyoffice/" . $fileId;
+        $this->groupFolderView->mkdir($path);
+        $this->groupFolderView->file_put_contents($path . "/" . $mtime . ".zip", "changes");
+        $this->groupFolderView->file_put_contents($path . "/1000.zip", "changes");
+
+        $this->runJob();
+
+        $this->assertFalse($this->groupFolderView->file_exists("onlyoffice/999999991"));
+        $this->assertTrue($this->groupFolderView->file_exists($path . "/" . $mtime . ".zip"));
+        $this->assertTrue($this->groupFolderView->file_exists($path . "/1000.zip"));
+    }
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -160,6 +160,11 @@
       <code><![CDATA[TimedJob]]></code>
     </UndefinedClass>
   </file>
+  <file src="lib/Cron/HistoryCleanup.php">
+    <UndefinedClass>
+      <code><![CDATA[TimedJob]]></code>
+    </UndefinedClass>
+  </file>
   <file src="lib/DirectEditor.php">
     <UndefinedClass>
       <code><![CDATA[IEditor]]></code>
@@ -280,7 +285,6 @@
   <file src="lib/FileVersions.php">
     <UndefinedClass>
       <code><![CDATA[?File]]></code>
-      <code><![CDATA[Database]]></code>
       <code><![CDATA[FileInfo]]></code>
       <code><![CDATA[FileInfo]]></code>
       <code><![CDATA[FileInfo]]></code>
@@ -293,13 +297,14 @@
       <code><![CDATA[IUser]]></code>
       <code><![CDATA[View]]></code>
       <code><![CDATA[View]]></code>
-      <code><![CDATA[View]]></code>
+      <code><![CDATA[\OCP\Server]]></code>
       <code><![CDATA[\OCP\Server]]></code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code><![CDATA[FileInfo]]></code>
     </UndefinedDocblockClass>
     <UndefinedFunction>
+      <code><![CDATA[\OCP\Log\logger('onlyoffice')]]></code>
       <code><![CDATA[\OCP\Log\logger('onlyoffice')]]></code>
     </UndefinedFunction>
   </file>
@@ -356,6 +361,11 @@
     </UndefinedClass>
   </file>
   <file src="lib/Listeners/FilesListener.php">
+    <UndefinedClass>
+      <code><![CDATA[IEventListener]]></code>
+    </UndefinedClass>
+  </file>
+  <file src="lib/Listeners/GroupFolderVersionsListener.php">
     <UndefinedClass>
       <code><![CDATA[IEventListener]]></code>
     </UndefinedClass>


### PR DESCRIPTION
The changes/history data stored under `<user>/onlyoffice/<fileId>` and `__groupfolders/onlyoffice/<fileId>` was only removed in reaction to events, and several deletion paths never emit them:

- deleting a folder does not dispatch `NodeDeletedEvent` for the files inside it, orphaning their history folders
- the `\OCP\Versions` `preDelete` hook handler resolves the file against the session filesystem, which fails for shared files and always for the retention cron, so changes of expired versions leak
- group folder version expiry bypasses the files_versions hooks entirely, and removing a whole group folder is silent
- the admin clear history action only iterated users of the local database backend and checked a wrong group folder path

Add a weekly background job that reconciles the history storage with the existing files and versions, listen to the groupfolders version expiry events, and clear history for seen users of all backends.