### PR TITLE
fix(viewer): always register OCA.Viewer handler on the Files app

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -518,7 +518,12 @@ function registerFileActions() {
 
 			return true
 		},
-		exec: fileOpenHandler,
+		exec: (file, view, dir) => {
+			if (window.OCA?.Viewer?.file === file.path) {
+				return null
+			}
+			return fileOpenHandler(file, view, dir)
+		},
 		default: DefaultType.HIDDEN,
 		order: -2,
 	})

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -44,56 +44,56 @@ if (!OCA.Onlyoffice) {
 	}
 
 	OCA.Onlyoffice.setting = loadState(OCA.Onlyoffice.AppName, 'settings')
+}
 
-	const OnlyofficeViewerVue = {
-		name: 'OnlyofficeViewerVue',
-		render(createElement) {
-			const self = this
+const OnlyofficeViewerVue = {
+	name: 'OnlyofficeViewerVue',
+	render(createElement) {
+		const self = this
 
-			return createElement('iframe', {
-				attrs: {
-					id: 'onlyofficeViewerFrame',
-					scrolling: 'no',
-					src: self.url + '&inframe=true&inviewer=true',
-				},
-				on: {
-					load() {
-						self.doneLoading()
-					},
-				},
-			})
-		},
-		props: {
-			filename: {
-				type: String,
-				default: null,
+		return createElement('iframe', {
+			attrs: {
+				id: 'onlyofficeViewerFrame',
+				scrolling: 'no',
+				src: self.url + '&inframe=true&inviewer=true',
 			},
-			fileid: {
-				type: Number,
-				default: null,
+			on: {
+				load() {
+					self.doneLoading()
+				},
 			},
-		},
-		data() {
-			return {
-				url: generateUrl('/apps/' + OCA.Onlyoffice.AppName + '/{fileId}?filePath={filePath}', {
-					fileId: this.fileid,
-					filePath: this.filename,
-				}),
-			}
-		},
-	}
-
-	if (OCA.Viewer) {
-		OCA.Onlyoffice.frameSelector = '#onlyofficeViewerFrame'
-
-		const mimes = Object.values(OCA.Onlyoffice.setting.formats)
-			.filter((format) => format.def)
-			.flatMap((format) => format.mime)
-		OCA.Viewer.registerHandler({
-			id: OCA.Onlyoffice.AppName,
-			group: null,
-			mimes,
-			component: OnlyofficeViewerVue,
 		})
-	}
+	},
+	props: {
+		filename: {
+			type: String,
+			default: null,
+		},
+		fileid: {
+			type: Number,
+			default: null,
+		},
+	},
+	data() {
+		return {
+			url: generateUrl('/apps/' + OCA.Onlyoffice.AppName + '/{fileId}?filePath={filePath}', {
+				fileId: this.fileid,
+				filePath: this.filename,
+			}),
+		}
+	},
+}
+
+if (OCA.Viewer) {
+	OCA.Onlyoffice.frameSelector = '#onlyofficeViewerFrame'
+
+	const mimes = Object.values(OCA.Onlyoffice.setting.formats)
+		.filter((format) => format.def)
+		.flatMap((format) => format.mime)
+	OCA.Viewer.registerHandler({
+		id: OCA.Onlyoffice.AppName,
+		group: null,
+		mimes,
+		component: OnlyofficeViewerVue,
+	})
 }


### PR DESCRIPTION
### What this is

A reapply of the two commits already on the `fix/viewer-register` branch, onto `feature/nc-33`. **Both are @mwgiorno's original work** — I have not changed what they do, only rebased them onto this line and resolved one formatting conflict. Authorship is preserved on both commits.

- `533e045a` — *fix(viewer): always register handler when OCA.Viewer is present*
- `14f0871c` — *fix(main): skip editor open when Viewer just took the file*

### Why it's needed on this branch

`fix/viewer-register` is cut from `develop`, which is the 9.14.x line (`@nextcloud/files ^3.12.2`). It hasn't been forward-ported to `feature/nc-33`, the 10.x / NC 33–34 line (`@nextcloud/files ^4.0.0`). So the bug is still present on `feature/nc-33` and in released v10.1.2.

### The bug

On the Files app, `src/viewer.js` never registers its Viewer handler. The whole module body — including `OCA.Viewer.registerHandler()` — sits inside `if (!OCA.Onlyoffice) {`, but `onlyoffice-desktop.mjs` and `onlyoffice-main.mjs` both assign `OCA.Onlyoffice` unconditionally and are injected first, so the guard is always false. ONLYOFFICE therefore never appears in Nextcloud's Viewer registry, and Viewer-routed entry points fall back to a raw WebDAV download. Full analysis, runtime evidence and a controlled experiment in #1211.

### Conflict resolution

`533e045a` conflicted on `src/viewer.js` because the two lines differ in arrow-parameter style. I applied the commit's intent to this branch's own file and kept `feature/nc-33` formatting throughout. The change is purely structural — ignoring whitespace it is a single moved closing brace:

```
$ git diff -w upstream/feature/nc-33...HEAD -- src/viewer.js
+}
-}
```

`14f0871c` applied cleanly. ESLint passes (the one repo warning, `v-html` in `EmptyJwtInfoDialog.vue`, is pre-existing and unrelated).

### Why both commits are needed together

Once the handler registers, `main.js`'s default file action also fires and the file opens twice. `14f0871c` stands that action down when the Viewer has already taken the file. Verified below — normal opens stay at exactly one editor instance.

### Verification

Nextcloud 34.0.2.1, connector 10.1.2, ONLYOFFICE Docs 9.4.0.129, headless Chrome 151. Before = pristine `feature/nc-33`; after = same tree plus these two commits.

| | before | after |
|---|---|---|
| `OCA.Viewer` handler registry | `images, videos, audios, text, pdf` | `… onlyoffice …` |
| office mimes registered | 0 | 5 |
| `OCA.Onlyoffice.frameSelector` | `null` | `#onlyofficeViewerFrame` |
| **docx** — versions tab, older revision | downloads the file | opens in ONLYOFFICE |
| **xlsx** — versions tab, older revision | downloads the file | opens in ONLYOFFICE |
| **pptx** — versions tab, older revision | downloads the file | opens in ONLYOFFICE |
| normal open, owner, Files app | 1 editor instance | 1 — no double-open |
| shared file opened by the recipient (2nd user) | 1 editor instance | 1 — no double-open |
| page errors | none | none |

Note that **no CI runs on this PR**: every workflow filters `branches: [master, develop]` for `pull_request`, so a PR based on `feature/nc-33` triggers nothing. The table above is the only signal reviewers get, which is why I've made it explicit rather than just asserting "tested".

### Why existing tests don't catch this

`tests/e2e/common/viewer.spec.ts` already asserts *"docx shared in Talk opens in ONLYOFFICE viewer"*, and it passes. It can't catch this bug: on a Talk page `LoadAdditionalScriptsEvent` doesn't fire, so `onlyoffice-main.mjs` never loads, `OCA.Onlyoffice` is unset, and `viewer.js`'s guard passes normally. The failure is specific to pages where another bundle initialises `OCA.Onlyoffice` first — i.e. the Files app. Existing coverage is structurally blind to it.

### Known follow-up — please read before merging

This changes the versions-tab failure mode rather than fully fixing that flow. Before: clicking an older revision silently downloads it. After: it routes to ONLYOFFICE and surfaces **"FileId is empty"**, because the Viewer passes `fileId` (camelCase, String) while the component declares `fileid` (lowercase, Number), so the URL is built with an unsubstituted `%7BfileId%7D`.

That is #1181 — **pre-existing and separate**; this PR neither causes nor fixes it. Worth noting that the registration bug was *masking* #1181: with no handler registered the code path was dead, which is likely why #1181 could not be reproduced.

I've deliberately kept this to the two original commits rather than adding a workaround, so it stays recognisably the existing fix. #1181 needs its own change — `EditorController::index` and `EditorApiController::config` accept no version parameter, so opening a specific revision is a feature gap, not a one-liner. Details in #1211.

No `CHANGELOG.md` entry, consistent with existing practice where the changelog is maintained by the team.

Fixes #1211