### PR TITLE
feat(editor): save over an existing file and name it in "Save as"

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -72,6 +72,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Lock\LockedException;
 use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -81,6 +82,10 @@ use Psr\Log\LoggerInterface;
  * Controller with the main functions
  */
 class EditorController extends Controller {
+
+    public const CONFLICT_ASK = "ask";
+    public const CONFLICT_OVERWRITE = "overwrite";
+    public const CONFLICT_KEEP_BOTH = "keepBoth";
 
     public function __construct(
         string $appName,
@@ -769,11 +774,13 @@ class EditorController extends Controller {
      * @param string $name - file name
      * @param string $dir - folder path
      * @param string $url - file url
+     * @param string $onConflict - what to do when the folder already contains a file with that name:
+     *                             ask the user (default), overwrite it or keep both files
      *
      * @return DataResponse
      */
     #[NoAdminRequired]
-    public function save(string $name, string $dir, string $url): DataResponse {
+    public function save(string $name, string $dir, string $url, string $onConflict = self::CONFLICT_ASK): DataResponse {
         $this->logger->debug("Save: $name");
 
         if (!$this->appConfig->isUserAllowedToUse()) {
@@ -793,10 +800,38 @@ class EditorController extends Controller {
             return new DataResponse(["error" => $this->trans->t("The required folder was not found")]);
         }
 
-        if (!($folder->isCreatable() && $folder->isUpdateable())) {
+        $name = basename($name);
+        if ($name === "" || $name === "." || $name === "..") {
+            $this->logger->error("Incorrect name for saving file: $name");
+            return new DataResponse(["error" => $this->trans->t("Can't create file")]);
+        }
+
+        $existingFile = null;
+        if ($folder->nodeExists($name)) {
+            $node = $folder->get($name);
+            if ($node instanceof File) {
+                $existingFile = $node;
+            }
+        }
+
+        if ($existingFile !== null && $onConflict === self::CONFLICT_KEEP_BOTH) {
+            $existingFile = null;
+        }
+
+        if ($existingFile !== null) {
+            if ($onConflict !== self::CONFLICT_OVERWRITE) {
+                return new DataResponse(["exists" => true, "name" => $name]);
+            }
+
+            if (!$existingFile->isUpdateable()) {
+                $this->logger->error("File for overwriting without permission: $dir/$name");
+                return new DataResponse(["error" => $this->trans->t("You don't have enough permission to update")]);
+            }
+        } elseif (!($folder->isCreatable() && $folder->isUpdateable())) {
             $this->logger->error("Folder for saving file without permission: $dir");
             return new DataResponse(["error" => $this->trans->t("You don't have enough permission to create")]);
         }
+
         $documentServerUrl = $this->appConfig->getDocumentServerUrl();
 
         if (empty($documentServerUrl)) {
@@ -822,13 +857,22 @@ class EditorController extends Controller {
             return new DataResponse(["error" => $this->trans->t("Download failed")]);
         }
 
-        $name = $folder->getNonExistingName($name);
-
         try {
-            $file = $folder->newFile($name);
+            if ($existingFile !== null) {
+                $file = $existingFile;
+            } else {
+                $name = $folder->getNonExistingName($name);
+                $file = $folder->newFile($name);
+            }
 
             $file->putContent($newData);
         } catch (NotPermittedException $e) {
+            $this->logger->error("Can't save file: $name", ["exception" => $e]);
+            return new DataResponse(["error" => $this->trans->t("Can't create file")]);
+        } catch (LockedException $e) {
+            $this->logger->error("File for saving is locked: $name", ["exception" => $e]);
+            return new DataResponse(["error" => $this->trans->t("The file is locked and can not be overwritten")]);
+        } catch (\Exception $e) {
             $this->logger->error("Can't save file: $name", ["exception" => $e]);
             return new DataResponse(["error" => $this->trans->t("Can't create file")]);
         }

--- a/src/editor.js
+++ b/src/editor.js
@@ -52,6 +52,7 @@ import {
 	sendMention,
 	setFavorite,
 } from './services/EditorService.ts'
+import { askConflictResolution, pickSaveAsTarget } from './utils/saveAs.ts'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -301,35 +302,60 @@ OCA.Onlyoffice.onRequestSaveAs = function(event) {
 			param: saveData,
 		}, '*')
 	} else {
-		getFilePickerBuilder(t(OCA.Onlyoffice.AppName, 'Save as'))
-			.setMimeTypeFilter(['httpd/unix-directory'])
-			.allowDirectories()
-			.startAt(saveData.dir)
-			.addButton({
-				label: t('core', 'Choose'),
-				callback: (nodes) => {
-					if (!nodes[0]) {
-						return
-					}
-					saveData.dir = nodes[0].path
-					OCA.Onlyoffice.editorSaveAs(saveData)
-				},
-				variant: 'primary',
-			})
-			.build()
-			.pickNodes()
-			.catch(() => {})
+		pickSaveAsTarget(saveData.name, saveData.dir).then((target) => {
+			if (!target) {
+				return
+			}
+
+			OCA.Onlyoffice.editorSaveAs({ ...saveData, ...target })
+		})
 	}
 }
 
 OCA.Onlyoffice.editorSaveAs = function(saveData) {
 	saveAs(saveData).then((response) => {
+		if (response.exists) {
+			OCA.Onlyoffice.onSaveAsConflict(saveData)
+			return
+		}
+
 		if (response.error) {
 			OCA.Onlyoffice.showMessage(response.error, 'error')
 			return
 		}
 
+		if (OCA.Onlyoffice.inframe) {
+			window.parent.postMessage({
+				method: 'editorSaveAsResult',
+				param: {
+					dir: saveData.dir,
+					name: response.name,
+					overwritten: saveData.onConflict === 'overwrite',
+				},
+			}, '*')
+		}
+
 		OCA.Onlyoffice.showMessage(t(OCA.Onlyoffice.AppName, 'File saved') + ' (' + response.name + ')')
+	}).catch(() => {
+		OCA.Onlyoffice.showMessage(t(OCA.Onlyoffice.AppName, "Can't create file"), 'error')
+	})
+}
+
+OCA.Onlyoffice.onSaveAsConflict = function(saveData) {
+	if (OCA.Onlyoffice.inframe) {
+		window.parent.postMessage({
+			method: 'editorSaveAsConflict',
+			param: saveData,
+		}, '*')
+		return
+	}
+
+	askConflictResolution(saveData.name).then((onConflict) => {
+		if (!onConflict) {
+			return
+		}
+
+		OCA.Onlyoffice.editorSaveAs({ ...saveData, onConflict })
 	})
 }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -52,7 +52,8 @@ import {
 	sendMention,
 	setFavorite,
 } from './services/EditorService.ts'
-import { askConflictResolution, pickSaveAsTarget } from './utils/saveAs.ts'
+import { askConflictResolution } from './utils/saveAs.ts'
+import { askSaveAsTarget } from './utils/saveAsDialog.ts'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -302,7 +303,7 @@ OCA.Onlyoffice.onRequestSaveAs = function(event) {
 			param: saveData,
 		}, '*')
 	} else {
-		pickSaveAsTarget(saveData.name, saveData.dir).then((target) => {
+		askSaveAsTarget(saveData.name, saveData.dir).then((target) => {
 			if (!target) {
 				return
 			}

--- a/src/listener.js
+++ b/src/listener.js
@@ -34,7 +34,15 @@
  */
 
 import { getFilePickerBuilder, showError, showSuccess } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
+import {
+	getClient,
+	getDefaultPropfind,
+	getRootPath,
+	resultToNode,
+} from '@nextcloud/files/dav'
 import { t } from '@nextcloud/l10n'
+import { askConflictResolution, pickSaveAsTarget } from './utils/saveAs.ts'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -52,25 +60,48 @@ OCA.Onlyoffice.onRequestClose = function() {
 	}
 }
 
+/**
+ * Pass the save data to the editor running in the frame
+ *
+ * @param saveData data of the file to save
+ */
+function saveAsInEditor(saveData) {
+	document.querySelector(OCA.Onlyoffice.frameSelector).contentWindow.OCA.Onlyoffice.editorSaveAs(saveData)
+}
+
 OCA.Onlyoffice.onRequestSaveAs = function(saveData) {
-	getFilePickerBuilder(t(OCA.Onlyoffice.AppName, 'Save as'))
-		.setMimeTypeFilter(['httpd/unix-directory'])
-		.allowDirectories()
-		.startAt(saveData.dir)
-		.addButton({
-			label: t('core', 'Choose'),
-			callback: (nodes) => {
-				if (!nodes[0]) {
-					return
-				}
-				saveData.dir = nodes[0].path
-				document.querySelector(OCA.Onlyoffice.frameSelector).contentWindow.OCA.Onlyoffice.editorSaveAs(saveData)
-			},
-			variant: 'primary',
+	pickSaveAsTarget(saveData.name, saveData.dir).then((target) => {
+		if (!target) {
+			return
+		}
+
+		saveAsInEditor({ ...saveData, ...target })
+	})
+}
+
+OCA.Onlyoffice.onSaveAsResult = async function({ dir, name, overwritten }) {
+	const path = (dir === '/' ? '' : dir) + '/' + name
+
+	try {
+		const result = await getClient().stat(`${getRootPath()}${path}`, {
+			details: true,
+			data: getDefaultPropfind(),
 		})
-		.build()
-		.pickNodes()
-		.catch(() => {})
+
+		emit(overwritten ? 'files:node:updated' : 'files:node:created', resultToNode(result.data))
+	} catch (error) {
+		console.error('Failed to refresh the file list', error)
+	}
+}
+
+OCA.Onlyoffice.onSaveAsConflict = function(saveData) {
+	askConflictResolution(saveData.name).then((onConflict) => {
+		if (!onConflict) {
+			return
+		}
+
+		saveAsInEditor({ ...saveData, onConflict })
+	})
 }
 
 OCA.Onlyoffice.onRequestInsertImage = function(imageMimes) {
@@ -206,6 +237,12 @@ window.addEventListener('message', function(event) {
 			break
 		case 'editorRequestSaveAs':
 			OCA.Onlyoffice.onRequestSaveAs(event.data.param)
+			break
+		case 'editorSaveAsConflict':
+			OCA.Onlyoffice.onSaveAsConflict(event.data.param)
+			break
+		case 'editorSaveAsResult':
+			OCA.Onlyoffice.onSaveAsResult(event.data.param)
 			break
 		case 'editorRequestInsertImage':
 			OCA.Onlyoffice.onRequestInsertImage(event.data.param)

--- a/src/listener.js
+++ b/src/listener.js
@@ -42,7 +42,8 @@ import {
 	resultToNode,
 } from '@nextcloud/files/dav'
 import { t } from '@nextcloud/l10n'
-import { askConflictResolution, pickSaveAsTarget } from './utils/saveAs.ts'
+import { askConflictResolution } from './utils/saveAs.ts'
+import { askSaveAsTarget } from './utils/saveAsDialog.ts'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -70,7 +71,7 @@ function saveAsInEditor(saveData) {
 }
 
 OCA.Onlyoffice.onRequestSaveAs = function(saveData) {
-	pickSaveAsTarget(saveData.name, saveData.dir).then((target) => {
+	askSaveAsTarget(saveData.name, saveData.dir).then((target) => {
 		if (!target) {
 			return
 		}

--- a/src/utils/saveAs.ts
+++ b/src/utils/saveAs.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { INode } from '@nextcloud/files'
+
+import { getDialogBuilder, getFilePickerBuilder } from '@nextcloud/dialogs'
+import { FileType } from '@nextcloud/files'
+import { t } from '@nextcloud/l10n'
+import { getFileExtension } from './files.ts'
+
+export const CONFLICT_OVERWRITE = 'overwrite'
+export const CONFLICT_KEEP_BOTH = 'keepBoth'
+
+export interface SaveAsTarget {
+	dir: string
+	name: string
+}
+
+/**
+ * Ask the user for the location to save the file to.
+ * Existing files are listed as well, picking one of the same type means saving over it.
+ *
+ * @param name file name proposed by the editor
+ * @param dir folder path to open the picker at
+ * @return the picked target, or null if the picker was closed
+ */
+export function pickSaveAsTarget(name: string, dir?: string): Promise<SaveAsTarget | null> {
+	const extension = getFileExtension(name)
+
+	return new Promise((resolve) => {
+		const builder = getFilePickerBuilder(t('onlyoffice', 'Save as'))
+			.allowDirectories()
+			.setCanPick((node: INode) => node.type === FileType.Folder
+				|| getFileExtension(node.basename) === extension)
+			.addButton({
+				label: t('core', 'Choose'),
+				callback: (nodes: INode[]) => {
+					const node = nodes[0]
+					if (!node) {
+						resolve(null)
+						return
+					}
+
+					if (node.type === FileType.Folder) {
+						resolve({ dir: node.path, name })
+						return
+					}
+
+					resolve({ dir: node.dirname, name: node.basename })
+				},
+				variant: 'primary',
+			})
+
+		if (dir) {
+			builder.startAt(dir)
+		}
+
+		builder.build().pickNodes().catch(() => resolve(null))
+	})
+}
+
+/**
+ * Ask the user what to do with the file already existing in the selected folder
+ *
+ * @param name name of the existing file
+ * @return the picked resolution, or null if the dialog was dismissed
+ */
+export function askConflictResolution(name: string): Promise<string | null> {
+	return new Promise((resolve) => {
+		getDialogBuilder(t('onlyoffice', 'File already exists'))
+			.setText(t('onlyoffice', 'The file "{name}" already exists in the selected folder.', { name }))
+			.setSeverity('warning')
+			.addButton({
+				label: t('core', 'Cancel'),
+				callback: () => resolve(null),
+			})
+			.addButton({
+				label: t('onlyoffice', 'Keep both'),
+				callback: () => resolve(CONFLICT_KEEP_BOTH),
+			})
+			.addButton({
+				label: t('onlyoffice', 'Overwrite'),
+				callback: () => resolve(CONFLICT_OVERWRITE),
+				variant: 'primary',
+			})
+			.build()
+			.show()
+			.catch(() => resolve(null))
+	})
+}

--- a/src/utils/saveAs.ts
+++ b/src/utils/saveAs.ts
@@ -46,6 +46,8 @@ export const CONFLICT_KEEP_BOTH = 'keepBoth'
 export interface SaveAsTarget {
 	dir: string
 	name: string
+	/** the user asked to name the file instead of taking the proposed name */
+	rename?: boolean
 }
 
 /**
@@ -59,27 +61,33 @@ export interface SaveAsTarget {
 export function pickSaveAsTarget(name: string, dir?: string): Promise<SaveAsTarget | null> {
 	const extension = getFileExtension(name)
 
+	const target = (nodes: INode[]): SaveAsTarget | null => {
+		const node = nodes[0]
+		if (!node) {
+			return null
+		}
+
+		return node.type === FileType.Folder
+			? { dir: node.path, name }
+			: { dir: node.dirname, name: node.basename }
+	}
+
 	return new Promise((resolve) => {
 		const builder = getFilePickerBuilder(t('onlyoffice', 'Save as'))
 			.allowDirectories()
 			.setCanPick((node: INode) => node.type === FileType.Folder
 				|| getFileExtension(node.basename) === extension)
 			.addButton({
-				label: t('core', 'Choose'),
+				label: t('onlyoffice', 'Change name'),
 				callback: (nodes: INode[]) => {
-					const node = nodes[0]
-					if (!node) {
-						resolve(null)
-						return
-					}
-
-					if (node.type === FileType.Folder) {
-						resolve({ dir: node.path, name })
-						return
-					}
-
-					resolve({ dir: node.dirname, name: node.basename })
+					const picked = target(nodes)
+					resolve(picked && { ...picked, rename: true })
 				},
+				variant: 'secondary',
+			})
+			.addButton({
+				label: t('onlyoffice', 'Save'),
+				callback: (nodes: INode[]) => resolve(target(nodes)),
 				variant: 'primary',
 			})
 

--- a/src/utils/saveAsDialog.ts
+++ b/src/utils/saveAsDialog.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { SaveAsTarget } from './saveAs.ts'
+
+import { spawnDialog } from '@nextcloud/vue/functions/dialog'
+import SaveAsDialog from '../views/SaveAsDialog.vue'
+import { pickSaveAsTarget } from './saveAs.ts'
+
+/**
+ * Ask the user where to save the file, and for a name only when the proposed one is not wanted
+ *
+ * @param name file name proposed by the editor
+ * @param dir folder path of the edited document
+ * @return the chosen target, or null if the user gave up
+ */
+export async function askSaveAsTarget(name: string, dir?: string): Promise<SaveAsTarget | null> {
+	const target = await pickSaveAsTarget(name, dir)
+	if (!target?.rename) {
+		return target
+	}
+
+	return await spawnDialog(SaveAsDialog, { name: target.name, dir: target.dir })
+}

--- a/src/views/SaveAsDialog.vue
+++ b/src/views/SaveAsDialog.vue
@@ -1,0 +1,163 @@
+<!--
+  Copyright (C) Ascensio System SIA, 2009-2026
+
+  This program is a free software product. You can redistribute it and/or
+  modify it under the terms of the GNU Affero General Public License (AGPL)
+  version 3 as published by the Free Software Foundation, together with the
+  additional terms provided in the LICENSE file.
+
+  This program is distributed WITHOUT ANY WARRANTY; without even the implied
+  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+  details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+
+  You can contact Ascensio System SIA by email at info@onlyoffice.com
+  or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+  LV-1050, Latvia, European Union.
+
+  The interactive user interfaces in modified versions of the Program
+  are required to display Appropriate Legal Notices in accordance with
+  Section 5 of the GNU AGPL version 3.
+
+  No trademark rights are granted under this License.
+
+  All non-code elements of the Product, including illustrations,
+  icon sets, and technical writing content, are licensed under the
+  Creative Commons Attribution-ShareAlike 4.0 International License:
+  https://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+  This license applies only to such non-code elements and does not
+  modify or replace the licensing terms applicable to the Program's
+  source code, which remains licensed under the GNU Affero General
+  Public License v3.
+
+  SPDX-License-Identifier: AGPL-3.0-only
+-->
+<template>
+	<NcDialog
+		class="onlyoffice-save-as"
+		:name="t('onlyoffice', 'Save as')"
+		:buttons="buttons"
+		@update:open="emit('close', null)">
+		<div class="onlyoffice-save-as__content">
+			<div class="onlyoffice-save-as__name">
+				<NcTextField
+					v-model="baseName"
+					:label="t('onlyoffice', 'File name')"
+					:error="!!error"
+					:helperText="error"
+					@keydown.enter="save" />
+				<span v-if="extension" class="onlyoffice-save-as__extension">.{{ extension }}</span>
+			</div>
+			<p class="onlyoffice-save-as__folder">
+				{{ t('onlyoffice', 'Save in {folder}', { folder: dir }) }}
+			</p>
+		</div>
+	</NcDialog>
+</template>
+
+<script setup lang="ts">
+import type { SaveAsTarget } from '../utils/saveAs.ts'
+
+import { t } from '@nextcloud/l10n'
+import { computed, ref } from 'vue'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import { getFileExtension } from '../utils/files.ts'
+
+const props = defineProps<{
+	name: string
+	dir: string
+}>()
+
+const emit = defineEmits<{
+	close: [value: SaveAsTarget | null]
+}>()
+
+const extension = getFileExtension(props.name)
+
+const dir = props.dir || '/'
+const baseName = ref(splitName(props.name))
+
+const error = computed(() => {
+	if (baseName.value.trim() === '') {
+		return t('onlyoffice', 'File name cannot be empty')
+	}
+
+	if (baseName.value.includes('/')) {
+		return t('onlyoffice', 'File name cannot contain "/"')
+	}
+
+	return ''
+})
+
+const buttons = computed(() => [
+	{
+		label: t('core', 'Cancel'),
+		variant: 'secondary',
+		size: 'large',
+		callback: () => emit('close', null),
+	},
+	{
+		label: t('onlyoffice', 'Save'),
+		variant: 'primary',
+		size: 'large',
+		disabled: !!error.value,
+		callback: () => save(),
+	},
+])
+
+/**
+ * @param name file name to take the extension off
+ * @return the file name without its extension
+ */
+function splitName(name: string): string {
+	return extension ? name.slice(0, name.length - extension.length - 1) : name
+}
+
+/**
+ * Close the dialog with the chosen target
+ */
+function save() {
+	if (error.value) {
+		return
+	}
+
+	emit('close', {
+		dir,
+		name: baseName.value.trim() + (extension ? '.' + extension : ''),
+	})
+}
+</script>
+
+<style scoped lang="scss">
+.onlyoffice-save-as__content {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding-block-end: 12px;
+}
+
+.onlyoffice-save-as__name {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.onlyoffice-save-as__extension {
+	color: var(--color-text-maxcontrast);
+}
+
+.onlyoffice-save-as__folder {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.onlyoffice-save-as__path {
+	overflow: hidden;
+	flex: 1;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	color: var(--color-text-maxcontrast);
+}
+</style>


### PR DESCRIPTION
### What

Two changes to "Save as", one per commit.

**1. Saving over an existing file.** The file picker filtered on `httpd/unix-directory`, so it listed folders only, and `EditorController::save()` always ran the name through `getNonExistingName()`. Exporting a document onto a file that already existed silently produced `name (2).pdf`, and there was no way to see what the target folder contained in the first place.

The picker now lists the files as well; those of the same type as the exported document can be picked as the target, the others stay visible but are not selectable. When the resulting name is taken, the user is asked what to do: overwrite, keep both (the previous behaviour) or cancel. The answer travels to the backend as the new `onConflict` parameter of the save endpoint (`ask` by default, plus `overwrite` and `keepBoth`); with `ask` the endpoint reports the conflict back **before** contacting the Document Server, so the file is downloaded only once the user has decided.

Overwriting writes through the existing file, so Nextcloud keeps a version of the previous content and `NodeWrittenEvent` drops the document key — reopening the file in ONLYOFFICE shows the new content instead of the cached one. Permissions are checked on the file being overwritten rather than on the parent folder, and a locked file or an unexpected storage failure is reported to the user instead of failing silently. Finally, the file list of the window hosting the editor is refreshed through the event bus, so the saved file shows up without reloading the page.

**2. Naming the file.** The name came from the editor with no way to change it, so naming a copy meant saving it and renaming it afterwards in the Files app. The picker now carries a secondary "Change name" button that opens a small dialog with the name filled in and the chosen folder already settled; the extension is kept out of the input field so the name cannot contradict the exported format. The common paths — saving where the document lives, saving over an existing file — still take a single window.

This is the part requested in #611, whose second half (offering the files of the same type as the document being saved) is covered by the picker itself.

### Why it matters beyond convenience

Users who export many documents to PDF over existing files had to leave Nextcloud to do it, writing directly to the underlying storage. That path does not emit `NodeWrittenEvent`, so the document key survives and the editor keeps serving its cached copy of the file — the very thing they were trying to update. Doing the overwrite through Nextcloud avoids that entirely.

### Notes for reviewers

- The name dialog is a component of this app because the Nextcloud file picker has no name field: that is nextcloud-libraries/nextcloud-dialogs#2491, still open, where the library maintainer suggests exactly this approach — a custom picker button opening a dialog for the name. If a `fileName` prop lands in the library, this dialog can be dropped in favour of it.
- Default behaviour is unchanged: with no name clash the save works as before, and "Keep both" is the old `getNonExistingName()` path.
- `POST /ajax/save` gains an optional `onConflict` parameter; existing callers that omit it get the conflict question instead of a silent copy.

### Testing

Tested against Nextcloud 33.0.6 with ONLYOFFICE Docs 9.4.0, both with the editor in a frame inside the Files app and as a full page:

- saving a new name, saving over a selected file, and "keep both" on a clashing name;
- overwrite refused with a clear message on a file shared read-only, with nothing written;
- the overwritten file keeps a version of its previous content, and its row in `oc_onlyoffice_filekey` is dropped;
- the file list updates without a page reload in the window hosting the editor.

Not covered by manual testing: the locked-file path (`LockedException`), which is handled but was not reproduced.

Closes #611

<img width="1400" height="900" alt="1-picker-with-files" src="https://github.com/user-attachments/assets/9604754f-c334-406f-80c3-eaeb980434b1" />
<img width="1400" height="900" alt="2-conflict-dialog" src="https://github.com/user-attachments/assets/5681cf82-80b1-4637-8bb7-12051357bd8b" />
<img width="1400" height="900" alt="3-name-dialog" src="https://github.com/user-attachments/assets/7f62bd14-3f0e-4747-b235-2cc4b67fc8d6" />
